### PR TITLE
Rework "replies" into "sessions"

### DIFF
--- a/aries_staticagent/message.py
+++ b/aries_staticagent/message.py
@@ -54,6 +54,11 @@ class Message(dict):
         return self['@id']
 
     @property
+    def thread(self):
+        """Shortcut to msg['~thread'], if present."""
+        return self.get('~thread', {'thid': None})
+
+    @property
     def doc_uri(self) -> str:
         """ Get type doc_uri """
         return self._type.doc_uri

--- a/aries_staticagent/utils.py
+++ b/aries_staticagent/utils.py
@@ -67,3 +67,25 @@ async def http_send(msg: bytes, endpoint: str) -> Optional[bytes]:
                 return body
 
     return None
+
+
+# TODO: Persist websocket until return_route = None sent
+async def ws_send(msg: bytes, endpoint: str) -> Optional[bytes]:
+    """Send over WS.
+
+    This send method is experimental and should not be used for more than
+    experimenting. This method is very inefficient as it throws out the created
+    websocket after receiving only a single msg.
+    """
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(endpoint) as sock:
+            await sock.send_bytes(msg)
+            async for msg in sock:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    return msg.data
+
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    raise Exception(
+                        'ws connection closed with exception %s' %
+                        sock.exception()
+                    )

--- a/examples/return_route_server.py
+++ b/examples/return_route_server.py
@@ -33,8 +33,8 @@ def main():
     async def handle(request):
         """aiohttp handle POST."""
         response = []
-        with conn.reply_handler(response.append):
-            await conn.handle(await request.read())
+        with conn.session(response.append) as session:
+            await conn.handle(await request.read(), session)
 
         if response:
             return web.Response(body=response.pop())

--- a/examples/webserver_aiohttp.py
+++ b/examples/webserver_aiohttp.py
@@ -28,8 +28,8 @@ def main():
     async def handle(request):
         """aiohttp handle POST."""
         response = []
-        with conn.reply_handler(response.append):
-            await conn.handle(await request.read())
+        with conn.session(response.append) as session:
+            await conn.handle(await request.read(), session)
 
         if response:
             return web.Response(text=response.pop())

--- a/examples/webserver_with_websockets.py
+++ b/examples/webserver_with_websockets.py
@@ -1,0 +1,72 @@
+"""Webserver with websockets example."""
+
+import aiohttp
+from aiohttp import web
+
+from aries_staticagent import StaticConnection, utils
+
+from common import config
+
+
+def main():
+    """Create StaticConnection and start web server."""
+    args = config()
+    conn = StaticConnection(
+        (args.my_verkey, args.my_sigkey),
+        their_vk=args.their_verkey,
+        endpoint=args.endpoint,
+    )
+
+    @conn.route("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message")
+    async def basic_message(msg, conn):
+        """Respond to a basic message."""
+        await conn.send_async({
+            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+                     "basicmessage/1.0/message",
+            "~l10n": {"locale": "en"},
+            "sent_time": utils.timestamp(),
+            "content": "You said: {}".format(msg['content'])
+        })
+
+    async def ws_handle(request):
+        """Handle WS requests."""
+        sock = web.WebSocketResponse()
+        await sock.prepare(request)
+
+        with conn.session(sock.send_bytes) as session:
+            async for msg in sock:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    await conn.handle(msg.data, session)
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    print(
+                        'ws connection closed with exception %s' %
+                        sock.exception()
+                    )
+
+                if not session.returning():
+                    await sock.close()
+
+        return sock
+
+    async def post_handle(request):
+        """Handle posted messages."""
+        response = []
+        with conn.session(response.append) as session:
+            await conn.handle(await request.read(), session)
+
+        if response:
+            return web.Response(text=response.pop())
+
+        raise web.HTTPAccepted()
+
+    app = web.Application()
+    app.add_routes([
+        web.get('/', ws_handle),
+        web.post('/', post_handle)
+    ])
+
+    web.run_app(app, port=args.port)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR evolves the return route handling to be more robust, handling the presence of multiple sessions (transport-layer connections accepting responses) with differing return route values. These changes should also better support implementing inbound web socket connections.