### PR TITLE
Update types to didcomm.org URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ With the static agent connection `a`, to send messages to the full agent:
 
 ```python
 conn.send({
-    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message",
+    "@type": "https://didcomm.org/basicmessage/1.0/message",
     "~l10n": {"locale": "en"},
     "sent_time": utils.timestamp(),
     "content": "The Cron Script has been executed."
@@ -130,7 +130,7 @@ conn.send({
 An asynchronous method is also provided:
 ```python
 await conn.send_async({
-    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message",
+    "@type": "https://didcomm.org/basicmessage/1.0/message",
     "~l10n": {"locale": "en"},
     "sent_time": utils.timestamp(),
     "content": "The Cron Script has been executed."
@@ -154,11 +154,11 @@ from aries_staticagent import StaticConnection, utils
 conn = StaticConnection((args.mypublickey, args.myprivatekey), their_vk=args.endpointkey, endpoint=args.endpoint)
 
 # Register a handler for the basicmessage/1.0/message message type
-@conn.route("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message")
+@conn.route("https://didcomm.org/basicmessage/1.0/message")
 async def basic_message(msg, conn):
     # Respond to the received basic message by sending another basic message back
     await conn.send_async({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message",
+        "@type": "https://didcomm.org/basicmessage/1.0/message",
         "~l10n": {"locale": "en"},
         "sent_time": utils.timestamp(),
         "content": "You said: {}".format(msg['content'])

--- a/aries_staticagent/utils.py
+++ b/aries_staticagent/utils.py
@@ -45,7 +45,7 @@ def ensure_key_b58(key: Union[bytes, str]):
     raise TypeError('key must be bytes or str')
 
 
-FORWARD = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/routing/1.0/forward'
+FORWARD = 'https://didcomm.org/routing/1.0/forward'
 
 
 def forward_msg(to: Union[bytes, str], msg: dict):

--- a/docs/aries_staticagent/crypto.html
+++ b/docs/aries_staticagent/crypto.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.crypto API documentation</title>
 <meta name="description" content="Crypto neccessary for packing and unpacking a message …" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -56,9 +58,14 @@ class CryptoError(Exception):
     &#34;&#34;&#34; CryptoError raised on failed crypto call. &#34;&#34;&#34;
 
 
-def b64_to_bytes(val: str, urlsafe=False) -&gt; bytes:
+def b64_to_bytes(val: Union[str, bytes], urlsafe=False) -&gt; bytes:
     &#34;&#34;&#34;Convert a base 64 string to bytes.&#34;&#34;&#34;
+    if isinstance(val, str):
+        val = val.encode(&#39;ascii&#39;)
     if urlsafe:
+        missing_padding = len(val) % 4
+        if missing_padding:
+            val += b&#39;=&#39; * (4 - missing_padding)
         return base64.urlsafe_b64decode(val)
     return base64.b64decode(val)
 
@@ -188,13 +195,13 @@ def sign_message_field(field_value: Dict, signer: str, secret: bytes) -&gt; Dict
     &#34;&#34;&#34;
     timestamp_bytes = struct.pack(&#34;&gt;Q&#34;, int(time.time()))
     sig_data_bytes = timestamp_bytes + json.dumps(field_value).encode(&#39;ascii&#39;)
-    sig_data = base64.urlsafe_b64encode(sig_data_bytes).decode(&#39;ascii&#39;)
+    sig_data = bytes_to_b64(sig_data_bytes, urlsafe=True)
 
     signature_bytes = nacl.bindings.crypto_sign(
         sig_data_bytes,
         secret
     )[:nacl.bindings.crypto_sign_BYTES]
-    signature = base64.urlsafe_b64encode(signature_bytes).decode(&#39;ascii&#39;)
+    signature = bytes_to_b64(signature_bytes, urlsafe=True)
 
     return {
         &#34;@type&#34;: &#34;did:sov:BzCbsNYhMrjHiqZDTUASHg;spec&#34;
@@ -207,10 +214,8 @@ def sign_message_field(field_value: Dict, signer: str, secret: bytes) -&gt; Dict
 
 def verify_signed_message_field(signed_field: Dict) -&gt; Tuple[str, Dict]:
     &#34;&#34;&#34; Verify a signed message field &#34;&#34;&#34;
-    data_bytes = base64.urlsafe_b64decode(signed_field[&#39;sig_data&#39;])
-    signature_bytes = base64.urlsafe_b64decode(
-        signed_field[&#39;signature&#39;].encode(&#39;ascii&#39;)
-    )
+    data_bytes = b64_to_bytes(signed_field[&#39;sig_data&#39;], urlsafe=True)
+    signature_bytes = b64_to_bytes(signed_field[&#39;signature&#39;], urlsafe=True)
     nacl.bindings.crypto_sign_open(
         signature_bytes + data_bytes,
         b58_to_bytes(signed_field[&#39;signer&#39;])
@@ -479,7 +484,7 @@ def locate_pack_recipient_key(
             cek = nacl.bindings.crypto_box_seal_open(encrypted_key, pk, sk)
         return cek, sender_vk, recip_vk_b58
     raise ValueError(
-        &#34;No corresponding recipient key found in {}&#34;.format(not_found)
+        &#34;Verkey {} not found in {}&#34;.format(bytes_to_b58(my_verkey), not_found)
     )
 
 
@@ -650,10 +655,10 @@ def unpack_message(
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="aries_staticagent.crypto.anon_crypt_message"><code class="name flex">
-<span>def <span class="ident">anon_crypt_message</span></span>(<span>message, to_verkey)</span>
+<span>def <span class="ident">anon_crypt_message</span></span>(<span>message: bytes, to_verkey: bytes) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Apply anon_crypt to a binary message.</p>
+<div class="desc"><p>Apply anon_crypt to a binary message.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>message</code></strong></dt>
@@ -662,10 +667,7 @@ def unpack_message(
 <dd>The verkey to encrypt the message for</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>anon</code> <code>encrypted</code> <code>message</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The anon encrypted message</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -688,10 +690,10 @@ def unpack_message(
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.anon_decrypt_message"><code class="name flex">
-<span>def <span class="ident">anon_decrypt_message</span></span>(<span>enc_message, secret)</span>
+<span>def <span class="ident">anon_decrypt_message</span></span>(<span>enc_message: bytes, secret: bytes) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Apply anon_decrypt to a binary message.</p>
+<div class="desc"><p>Apply anon_decrypt to a binary message.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>enc_message</code></strong></dt>
@@ -700,10 +702,7 @@ def unpack_message(
 <dd>The seed to use</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>decrypted</code> <code>message</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The decrypted message</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -729,10 +728,10 @@ def unpack_message(
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.auth_crypt_message"><code class="name flex">
-<span>def <span class="ident">auth_crypt_message</span></span>(<span>message, to_verkey, from_verkey, from_sigkey)</span>
+<span>def <span class="ident">auth_crypt_message</span></span>(<span>message: bytes, to_verkey: bytes, from_verkey: bytes, from_sigkey: bytes) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Apply auth_crypt to a binary message.</p>
+<div class="desc"><p>Apply auth_crypt to a binary message.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>message</code></strong></dt>
@@ -745,10 +744,7 @@ def unpack_message(
 <dd>Sender sigkey, included to auth encrypt the message</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>encrypted</code> <code>message</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The encrypted message</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -789,10 +785,10 @@ def unpack_message(
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.auth_decrypt_message"><code class="name flex">
-<span>def <span class="ident">auth_decrypt_message</span></span>(<span>enc_message, my_verkey, my_sigkey)</span>
+<span>def <span class="ident">auth_decrypt_message</span></span>(<span>enc_message: bytes, my_verkey: bytes, my_sigkey: bytes) ‑> Tuple[bytes, str]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Apply auth_decrypt to a binary message.</p>
+<div class="desc"><p>Apply auth_decrypt to a binary message.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>enc_message</code></strong></dt>
@@ -801,10 +797,7 @@ def unpack_message(
 <dd>Secret for signing keys</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>tuple</code> of (<code>decrypted</code> <code>message</code>, <code>sender</code> <code>verkey</code>)</dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>A tuple of (decrypted message, sender verkey)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -841,12 +834,12 @@ def unpack_message(
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.b58_to_bytes"><code class="name flex">
-<span>def <span class="ident">b58_to_bytes</span></span>(<span>val)</span>
+<span>def <span class="ident">b58_to_bytes</span></span>(<span>val: str) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Convert a base 58 string to bytes.</p>
+<div class="desc"><p>Convert a base 58 string to bytes.</p>
 <p>Small cache provided for key conversions which happen frequently in pack
-and unpack and message handling.</p></section>
+and unpack and message handling.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -863,28 +856,33 @@ def b58_to_bytes(val: str) -&gt; bytes:
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.b64_to_bytes"><code class="name flex">
-<span>def <span class="ident">b64_to_bytes</span></span>(<span>val, urlsafe=False)</span>
+<span>def <span class="ident">b64_to_bytes</span></span>(<span>val: Union[str, bytes], urlsafe=False) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Convert a base 64 string to bytes.</p></section>
+<div class="desc"><p>Convert a base 64 string to bytes.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def b64_to_bytes(val: str, urlsafe=False) -&gt; bytes:
+<pre><code class="python">def b64_to_bytes(val: Union[str, bytes], urlsafe=False) -&gt; bytes:
     &#34;&#34;&#34;Convert a base 64 string to bytes.&#34;&#34;&#34;
+    if isinstance(val, str):
+        val = val.encode(&#39;ascii&#39;)
     if urlsafe:
+        missing_padding = len(val) % 4
+        if missing_padding:
+            val += b&#39;=&#39; * (4 - missing_padding)
         return base64.urlsafe_b64decode(val)
     return base64.b64decode(val)</code></pre>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.bytes_to_b58"><code class="name flex">
-<span>def <span class="ident">bytes_to_b58</span></span>(<span>val)</span>
+<span>def <span class="ident">bytes_to_b58</span></span>(<span>val: bytes) ‑> str</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Convert a byte string to base 58.</p>
+<div class="desc"><p>Convert a byte string to base 58.</p>
 <p>Small cache provided for key conversions which happen frequently in pack
-and unpack and message handling.</p></section>
+and unpack and message handling.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -901,10 +899,10 @@ def bytes_to_b58(val: bytes) -&gt; str:
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.bytes_to_b64"><code class="name flex">
-<span>def <span class="ident">bytes_to_b64</span></span>(<span>val, urlsafe=False)</span>
+<span>def <span class="ident">bytes_to_b64</span></span>(<span>val: bytes, urlsafe=False) ‑> str</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Convert a byte string to base 64.</p></section>
+<div class="desc"><p>Convert a byte string to base 64.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -917,20 +915,17 @@ def bytes_to_b58(val: bytes) -&gt; str:
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.create_keypair"><code class="name flex">
-<span>def <span class="ident">create_keypair</span></span>(<span>seed=None)</span>
+<span>def <span class="ident">create_keypair</span></span>(<span>seed: bytes = None) ‑> Tuple[bytes, bytes]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Create a public and private signing keypair from a seed value.</p>
+<div class="desc"><p>Create a public and private signing keypair from a seed value.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>seed</code></strong></dt>
 <dd>Seed for keypair</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>tuple</code> of (<code>public</code> <code>key</code>, <code>secret</code> <code>key</code>)</dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>A tuple of (public key, secret key)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -955,20 +950,17 @@ def bytes_to_b58(val: bytes) -&gt; str:
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.decrypt_plaintext"><code class="name flex">
-<span>def <span class="ident">decrypt_plaintext</span></span>(<span>ciphertext, recips_bin, nonce, key)</span>
+<span>def <span class="ident">decrypt_plaintext</span></span>(<span>ciphertext: bytes, recips_bin: bytes, nonce: bytes, key: bytes) ‑> str</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Decrypt the payload of a packed message.</p>
+<div class="desc"><p>Decrypt the payload of a packed message.</p>
 <h2 id="args">Args</h2>
 <p>ciphertext:
 recips_bin:
 nonce:
 key:</p>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>decrypted</code> <code>string</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The decrypted string</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -996,10 +988,10 @@ key:</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.encrypt_plaintext"><code class="name flex">
-<span>def <span class="ident">encrypt_plaintext</span></span>(<span>message, add_data, key)</span>
+<span>def <span class="ident">encrypt_plaintext</span></span>(<span>message: str, add_data: bytes, key: bytes) ‑> Tuple[bytes, bytes, bytes]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Encrypt the payload of a packed message.</p>
+<div class="desc"><p>Encrypt the payload of a packed message.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>message</code></strong></dt>
@@ -1009,10 +1001,7 @@ key:</p>
 <dd>Key used for encryption</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>tuple</code> of (<code>ciphertext</code>, <code>nonce</code>, <code>tag</code>)</dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>A tuple of (ciphertext, nonce, tag)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1046,10 +1035,10 @@ key:</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.locate_pack_recipient_key"><code class="name flex">
-<span>def <span class="ident">locate_pack_recipient_key</span></span>(<span>recipients, my_verkey, my_sigkey)</span>
+<span>def <span class="ident">locate_pack_recipient_key</span></span>(<span>recipients: Sequence[dict], my_verkey: bytes, my_sigkey: bytes) ‑> Tuple[bytes, str, str]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Locate pack recipient key.</p>
+<div class="desc"><p>Locate pack recipient key.</p>
 <p>Decode the encryption key and sender verification key from a
 corresponding recipient block, if any is defined.</p>
 <h2 id="args">Args</h2>
@@ -1060,15 +1049,12 @@ corresponding recipient block, if any is defined.</p>
 <dd>Function used to find private key</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>tuple</code> of (<code>cek</code>, <code>sender_vk</code>, <code>recip_vk_b58</code>)</dt>
-<dd>&nbsp;</dd>
-</dl>
+<p>A tuple of (cek, sender_vk, recip_vk_b58)</p>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><strong><code>ValueError</code></strong></dt>
+<dt><code>ValueError</code></dt>
 <dd>If no corresponding recipient key found</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1146,15 +1132,15 @@ corresponding recipient block, if any is defined.</p>
             cek = nacl.bindings.crypto_box_seal_open(encrypted_key, pk, sk)
         return cek, sender_vk, recip_vk_b58
     raise ValueError(
-        &#34;No corresponding recipient key found in {}&#34;.format(not_found)
+        &#34;Verkey {} not found in {}&#34;.format(bytes_to_b58(my_verkey), not_found)
     )</code></pre>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.pack_message"><code class="name flex">
-<span>def <span class="ident">pack_message</span></span>(<span>message, to_verkeys, from_verkey=None, from_sigkey=None)</span>
+<span>def <span class="ident">pack_message</span></span>(<span>message: str, to_verkeys: Sequence[bytes], from_verkey: bytes = None, from_sigkey: bytes = None) ‑> collections.OrderedDict</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Assemble a packed message for a set of recipients, optionally including
+<div class="desc"><p>Assemble a packed message for a set of recipients, optionally including
 the sender.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -1168,10 +1154,7 @@ the sender.</p>
 <dd>The sender sigkey</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>encoded</code> <code>message</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The encoded message</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1221,10 +1204,10 @@ the sender.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.prepare_pack_recipient_keys"><code class="name flex">
-<span>def <span class="ident">prepare_pack_recipient_keys</span></span>(<span>to_verkeys, from_verkey=None, from_sigkey=None)</span>
+<span>def <span class="ident">prepare_pack_recipient_keys</span></span>(<span>to_verkeys: Sequence[bytes], from_verkey: bytes = None, from_sigkey: bytes = None) ‑> Tuple[str, bytes]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Assemble the recipients block of a packed message.</p>
+<div class="desc"><p>Assemble the recipients block of a packed message.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>to_verkeys</code></strong></dt>
@@ -1235,10 +1218,7 @@ the sender.</p>
 <dd>Sender Sigkey needed to authcrypt package</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>tuple</code> of (<code>json</code> <code>result</code>, <code>key</code>)</dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>A tuple of (json result, key)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1327,15 +1307,12 @@ the sender.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.random_seed"><code class="name flex">
-<span>def <span class="ident">random_seed</span></span>(<span>)</span>
+<span>def <span class="ident">random_seed</span></span>(<span>) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Generate a random seed value.</p>
+<div class="desc"><p>Generate a random seed value.</p>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>new</code> <code>random</code> <code>seed</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>A new random seed</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1352,10 +1329,10 @@ the sender.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.sign_message"><code class="name flex">
-<span>def <span class="ident">sign_message</span></span>(<span>message, secret)</span>
+<span>def <span class="ident">sign_message</span></span>(<span>message: bytes, secret: bytes) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Sign a message using a private signing key.</p>
+<div class="desc"><p>Sign a message using a private signing key.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>message</code></strong></dt>
@@ -1364,10 +1341,7 @@ the sender.</p>
 <dd>The private signing key</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>signature</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The signature</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1390,10 +1364,10 @@ the sender.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.sign_message_field"><code class="name flex">
-<span>def <span class="ident">sign_message_field</span></span>(<span>field_value, signer, secret)</span>
+<span>def <span class="ident">sign_message_field</span></span>(<span>field_value: Dict, signer: str, secret: bytes) ‑> Dict</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Sign a field of a message and return the value of a signature decorator.</p></section>
+<div class="desc"><p>Sign a field of a message and return the value of a signature decorator.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1403,13 +1377,13 @@ the sender.</p>
     &#34;&#34;&#34;
     timestamp_bytes = struct.pack(&#34;&gt;Q&#34;, int(time.time()))
     sig_data_bytes = timestamp_bytes + json.dumps(field_value).encode(&#39;ascii&#39;)
-    sig_data = base64.urlsafe_b64encode(sig_data_bytes).decode(&#39;ascii&#39;)
+    sig_data = bytes_to_b64(sig_data_bytes, urlsafe=True)
 
     signature_bytes = nacl.bindings.crypto_sign(
         sig_data_bytes,
         secret
     )[:nacl.bindings.crypto_sign_BYTES]
-    signature = base64.urlsafe_b64encode(signature_bytes).decode(&#39;ascii&#39;)
+    signature = bytes_to_b64(signature_bytes, urlsafe=True)
 
     return {
         &#34;@type&#34;: &#34;did:sov:BzCbsNYhMrjHiqZDTUASHg;spec&#34;
@@ -1421,10 +1395,10 @@ the sender.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.unpack_message"><code class="name flex">
-<span>def <span class="ident">unpack_message</span></span>(<span>enc_message, my_verkey, my_sigkey)</span>
+<span>def <span class="ident">unpack_message</span></span>(<span>enc_message: Union[Dict, bytes], my_verkey: bytes, my_sigkey: bytes) ‑> Tuple[str, Union[str, NoneType], str]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Decode a packed message.</p>
+<div class="desc"><p>Decode a packed message.</p>
 <p>Disassemble and unencrypt a packed message, returning the message content,
 verification key of the sender (if available), and verification key of the
 recipient.</p>
@@ -1436,21 +1410,18 @@ recipient.</p>
 <dd>Function to retrieve private key</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>A</code> <code>tuple</code> of (<code>message</code>, <code>sender_vk</code>, <code>recip_vk</code>)</dt>
-<dd>&nbsp;</dd>
-</dl>
+<p>A tuple of (message, sender_vk, recip_vk)</p>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><strong><code>ValueError</code></strong></dt>
+<dt><code>ValueError</code></dt>
 <dd>If the packed message is invalid</dd>
-<dt><strong><code>ValueError</code></strong></dt>
+<dt><code>ValueError</code></dt>
 <dd>If the packed message reipients are invalid</dd>
-<dt><strong><code>ValueError</code></strong></dt>
+<dt><code>ValueError</code></dt>
 <dd>If the pack algorithm is unsupported</dd>
-<dt><strong><code>ValueError</code></strong></dt>
+<dt><code>ValueError</code></dt>
 <dd>If the sender's public key was not provided</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1521,20 +1492,17 @@ recipient.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.validate_seed"><code class="name flex">
-<span>def <span class="ident">validate_seed</span></span>(<span>seed)</span>
+<span>def <span class="ident">validate_seed</span></span>(<span>seed: Union[str, bytes]) ‑> Union[bytes, NoneType]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Convert a seed parameter to standard format and check length.</p>
+<div class="desc"><p>Convert a seed parameter to standard format and check length.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>seed</code></strong></dt>
 <dd>The seed to validate</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>The</code> <code>validated</code> <code>and</code> <code>encoded</code> <code>seed</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>The validated and encoded seed</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1565,10 +1533,10 @@ recipient.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.verify_signed_message"><code class="name flex">
-<span>def <span class="ident">verify_signed_message</span></span>(<span>signed, verkey)</span>
+<span>def <span class="ident">verify_signed_message</span></span>(<span>signed: bytes, verkey: bytes) ‑> bool</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Verify a signed message according to a public verification key.</p>
+<div class="desc"><p>Verify a signed message according to a public verification key.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signed</code></strong></dt>
@@ -1577,10 +1545,7 @@ recipient.</p>
 <dd>The verkey to use in verification</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<dl>
-<dt><code>True</code> <code>if</code> <code>verified</code>, <code>else</code> <code>False</code></dt>
-<dd>&nbsp;</dd>
-</dl></section>
+<p>True if verified, else False</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1605,20 +1570,18 @@ recipient.</p>
 </details>
 </dd>
 <dt id="aries_staticagent.crypto.verify_signed_message_field"><code class="name flex">
-<span>def <span class="ident">verify_signed_message_field</span></span>(<span>signed_field)</span>
+<span>def <span class="ident">verify_signed_message_field</span></span>(<span>signed_field: Dict) ‑> Tuple[str, Dict]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Verify a signed message field</p></section>
+<div class="desc"><p>Verify a signed message field</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def verify_signed_message_field(signed_field: Dict) -&gt; Tuple[str, Dict]:
     &#34;&#34;&#34; Verify a signed message field &#34;&#34;&#34;
-    data_bytes = base64.urlsafe_b64decode(signed_field[&#39;sig_data&#39;])
-    signature_bytes = base64.urlsafe_b64decode(
-        signed_field[&#39;signature&#39;].encode(&#39;ascii&#39;)
-    )
+    data_bytes = b64_to_bytes(signed_field[&#39;sig_data&#39;], urlsafe=True)
+    signature_bytes = b64_to_bytes(signed_field[&#39;signature&#39;], urlsafe=True)
     nacl.bindings.crypto_sign_open(
         signature_bytes + data_bytes,
         b58_to_bytes(signed_field[&#39;signer&#39;])
@@ -1635,10 +1598,10 @@ recipient.</p>
 <dl>
 <dt id="aries_staticagent.crypto.CryptoError"><code class="flex name class">
 <span>class <span class="ident">CryptoError</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>...)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>CryptoError raised on failed crypto call.</p></section>
+<div class="desc"><p>CryptoError raised on failed crypto call.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1702,9 +1665,7 @@ recipient.</p>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/dispatcher.html
+++ b/docs/aries_staticagent/dispatcher.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.dispatcher API documentation</title>
 <meta name="description" content="Dispatcher" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -151,8 +153,8 @@ class Dispatcher:
 <span>class <span class="ident">Dispatcher</span></span>
 </code></dt>
 <dd>
-<section class="desc"><p>One of the fundamental aspects of an agent; responsible for dispatching
-messages to appropriate handlers.</p></section>
+<div class="desc"><p>One of the fundamental aspects of an agent; responsible for dispatching
+messages to appropriate handlers.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -234,10 +236,10 @@ messages to appropriate handlers.</p></section>
 <h3>Methods</h3>
 <dl>
 <dt id="aries_staticagent.dispatcher.Dispatcher.add_handler"><code class="name flex">
-<span>def <span class="ident">add_handler</span></span>(<span>self, handler)</span>
+<span>def <span class="ident">add_handler</span></span>(<span>self, handler: <a title="aries_staticagent.dispatcher.Handler" href="#aries_staticagent.dispatcher.Handler">Handler</a>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Add a handler to routing tables.</p></section>
+<div class="desc"><p>Add a handler to routing tables.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -253,10 +255,10 @@ messages to appropriate handlers.</p></section>
 </details>
 </dd>
 <dt id="aries_staticagent.dispatcher.Dispatcher.add_handlers"><code class="name flex">
-<span>def <span class="ident">add_handlers</span></span>(<span>self, handlers)</span>
+<span>def <span class="ident">add_handlers</span></span>(<span>self, handlers: Sequence[<a title="aries_staticagent.dispatcher.Handler" href="#aries_staticagent.dispatcher.Handler">Handler</a>])</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Add a list of handlers to routing tables.</p></section>
+<div class="desc"><p>Add a list of handlers to routing tables.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -271,7 +273,7 @@ messages to appropriate handlers.</p></section>
 <span>def <span class="ident">clear_handlers</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Clear routes</p></section>
+<div class="desc"><p>Clear routes</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -283,10 +285,10 @@ messages to appropriate handlers.</p></section>
 </details>
 </dd>
 <dt id="aries_staticagent.dispatcher.Dispatcher.dispatch"><code class="name flex">
-<span>async def <span class="ident">dispatch</span></span>(<span>self, msg, *args, **kwargs)</span>
+<span>async def <span class="ident">dispatch</span></span>(<span>self, msg: <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>, *args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Dispatch message to handler.</p></section>
+<div class="desc"><p>Dispatch message to handler.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -308,7 +310,7 @@ messages to appropriate handlers.</p></section>
 <span>def <span class="ident">remove_handler</span></span>(<span>self, handler)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Remove handler from routing tables.</p></section>
+<div class="desc"><p>Remove handler from routing tables.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -326,10 +328,10 @@ messages to appropriate handlers.</p></section>
 </details>
 </dd>
 <dt id="aries_staticagent.dispatcher.Dispatcher.select_handler"><code class="name flex">
-<span>def <span class="ident">select_handler</span></span>(<span>self, msg)</span>
+<span>def <span class="ident">select_handler</span></span>(<span>self, msg: <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Find the closest appropriate module for a given message.</p></section>
+<div class="desc"><p>Find the closest appropriate module for a given message.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -362,10 +364,10 @@ messages to appropriate handlers.</p></section>
 </dd>
 <dt id="aries_staticagent.dispatcher.Handler"><code class="flex name class">
 <span>class <span class="ident">Handler</span></span>
-<span>(</span><span>type_, handler, context=None)</span>
+<span>(</span><span>type_: <a title="aries_staticagent.type.Type" href="type.html#aries_staticagent.type.Type">Type</a>, handler: Callable, context=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>A Message Handler.</p></section>
+<div class="desc"><p>A Message Handler.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -397,15 +399,15 @@ messages to appropriate handlers.</p></section>
 <dl>
 <dt id="aries_staticagent.dispatcher.Handler.context"><code class="name">var <span class="ident">context</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.dispatcher.Handler.handler"><code class="name">var <span class="ident">handler</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.dispatcher.Handler.type"><code class="name">var <span class="ident">type</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -414,7 +416,7 @@ messages to appropriate handlers.</p></section>
 <span>async def <span class="ident">run</span></span>(<span>self, msg, *args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Call the handler with message.</p></section>
+<div class="desc"><p>Call the handler with message.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -429,10 +431,10 @@ messages to appropriate handlers.</p></section>
 </dd>
 <dt id="aries_staticagent.dispatcher.NoRegisteredHandlerException"><code class="flex name class">
 <span>class <span class="ident">NoRegisteredHandlerException</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>...)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Thrown when message has no registered handlers</p></section>
+<div class="desc"><p>Thrown when message has no registered handlers</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -491,9 +493,7 @@ messages to appropriate handlers.</p></section>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/index.html
+++ b/docs/aries_staticagent/index.html
@@ -3,21 +3,23 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent API documentation</title>
 <meta name="description" content="Aries Static Agent Library." />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
 <article id="content">
 <header>
-<h1 class="title">Module <code>aries_staticagent</code></h1>
+<h1 class="title">Package <code>aries_staticagent</code></h1>
 </header>
 <section id="section-intro">
 <p>Aries Static Agent Library.</p>
@@ -28,7 +30,9 @@
 <pre><code class="python">&#34;&#34;&#34; Aries Static Agent Library.
 &#34;&#34;&#34;
 
-from .static_connection import StaticConnection, MessageDeliveryError
+from .static_connection import (
+    StaticConnection, Keys, Target, MessageDeliveryError
+)
 from .module import Module, route
 from .message import Message
 
@@ -60,35 +64,35 @@ def keygen():
 <dl>
 <dt><code class="name"><a title="aries_staticagent.crypto" href="crypto.html">aries_staticagent.crypto</a></code></dt>
 <dd>
-<section class="desc"><p>Crypto neccessary for packing and unpacking a message …</p></section>
+<div class="desc"><p>Crypto neccessary for packing and unpacking a message …</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.dispatcher" href="dispatcher.html">aries_staticagent.dispatcher</a></code></dt>
 <dd>
-<section class="desc"><p>Dispatcher</p></section>
+<div class="desc"><p>Dispatcher</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.message" href="message.html">aries_staticagent.message</a></code></dt>
 <dd>
-<section class="desc"><p>Define Message base class.</p></section>
+<div class="desc"><p>Define Message base class.</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.module" href="module.html">aries_staticagent.module</a></code></dt>
 <dd>
-<section class="desc"><p>Module base class</p></section>
+<div class="desc"><p>Module base class</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.mtc" href="mtc.html">aries_staticagent.mtc</a></code></dt>
 <dd>
-<section class="desc"><p>Message Trust Context. See Aries RFC 0029: Message Trust Contexts …</p></section>
+<div class="desc"><p>Message Trust Context. See Aries RFC 0029: Message Trust Contexts …</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.static_connection" href="static_connection.html">aries_staticagent.static_connection</a></code></dt>
 <dd>
-<section class="desc"><p>Static Agent Connection.</p></section>
+<div class="desc"><p>Static Agent Connection.</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.type" href="type.html">aries_staticagent.type</a></code></dt>
 <dd>
-<section class="desc"><p>Message and Module Type related classes and helpers.</p></section>
+<div class="desc"><p>Message and Module Type related classes and helpers.</p></div>
 </dd>
 <dt><code class="name"><a title="aries_staticagent.utils" href="utils.html">aries_staticagent.utils</a></code></dt>
 <dd>
-<section class="desc"><p>General utils</p></section>
+<div class="desc"><p>General utils</p></div>
 </dd>
 </dl>
 </section>
@@ -101,8 +105,8 @@ def keygen():
 <span>def <span class="ident">keygen</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Convenience method for generating and printing a keypair and DID.
-DID is generated from the first 16 bytes of the VerKey.</p></section>
+<div class="desc"><p>Convenience method for generating and printing a keypair and DID.
+DID is generated from the first 16 bytes of the VerKey.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -159,9 +163,7 @@ DID is generated from the first 16 bytes of the VerKey.</p></section>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/message.html
+++ b/docs/aries_staticagent/message.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.message API documentation</title>
 <meta name="description" content="Define Message base class." />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -81,6 +83,11 @@ class Message(dict):
         return self[&#39;@id&#39;]
 
     @property
+    def thread(self):
+        &#34;&#34;&#34;Shortcut to msg[&#39;~thread&#39;], if present.&#34;&#34;&#34;
+        return self.get(&#39;~thread&#39;, {&#39;thid&#39;: None})
+
+    @property
     def doc_uri(self) -&gt; str:
         &#34;&#34;&#34; Get type doc_uri &#34;&#34;&#34;
         return self._type.doc_uri
@@ -148,7 +155,7 @@ class Message(dict):
 <span>def <span class="ident">generate_id</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Generate a message id.</p></section>
+<div class="desc"><p>Generate a message id.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -165,10 +172,10 @@ class Message(dict):
 <dl>
 <dt id="aries_staticagent.message.InvalidMessage"><code class="flex name class">
 <span>class <span class="ident">InvalidMessage</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>...)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Thrown when message is malformed.</p></section>
+<div class="desc"><p>Thrown when message is malformed.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -187,8 +194,8 @@ class Message(dict):
 <span>(</span><span>*args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Message base class.
-Inherits from dict meaning it behaves like a dictionary.</p></section>
+<div class="desc"><p>Message base class.
+Inherits from dict meaning it behaves like a dictionary.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -229,6 +236,11 @@ Inherits from dict meaning it behaves like a dictionary.</p></section>
     def id(self):  # pylint: disable=invalid-name
         &#34;&#34;&#34; Shortcut for msg[&#39;@id&#39;] &#34;&#34;&#34;
         return self[&#39;@id&#39;]
+
+    @property
+    def thread(self):
+        &#34;&#34;&#34;Shortcut to msg[&#39;~thread&#39;], if present.&#34;&#34;&#34;
+        return self.get(&#39;~thread&#39;, {&#39;thid&#39;: None})
 
     @property
     def doc_uri(self) -&gt; str:
@@ -293,10 +305,10 @@ Inherits from dict meaning it behaves like a dictionary.</p></section>
 <h3>Static methods</h3>
 <dl>
 <dt id="aries_staticagent.message.Message.deserialize"><code class="name flex">
-<span>def <span class="ident">deserialize</span></span>(<span>serialized)</span>
+<span>def <span class="ident">deserialize</span></span>(<span>serialized: Union[str, bytes]) ‑> <a title="aries_staticagent.message.Message" href="#aries_staticagent.message.Message">Message</a></span>
 </code></dt>
 <dd>
-<section class="desc"><p>Deserialize a message from a json string.</p></section>
+<div class="desc"><p>Deserialize a message from a json string.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -313,9 +325,9 @@ def deserialize(cls, serialized: Union[str, bytes]) -&gt; &#39;Message&#39;:
 </dl>
 <h3>Instance variables</h3>
 <dl>
-<dt id="aries_staticagent.message.Message.doc_uri"><code class="name">var <span class="ident">doc_uri</span></code></dt>
+<dt id="aries_staticagent.message.Message.doc_uri"><code class="name">var <span class="ident">doc_uri</span> : str</code></dt>
 <dd>
-<section class="desc"><p>Get type doc_uri</p></section>
+<div class="desc"><p>Get type doc_uri</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -328,7 +340,7 @@ def doc_uri(self) -&gt; str:
 </dd>
 <dt id="aries_staticagent.message.Message.id"><code class="name">var <span class="ident">id</span></code></dt>
 <dd>
-<section class="desc"><p>Shortcut for msg['@id']</p></section>
+<div class="desc"><p>Shortcut for msg['@id']</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -341,11 +353,11 @@ def id(self):  # pylint: disable=invalid-name
 </dd>
 <dt id="aries_staticagent.message.Message.mtc"><code class="name">var <span class="ident">mtc</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
-<dt id="aries_staticagent.message.Message.name"><code class="name">var <span class="ident">name</span></code></dt>
+<dt id="aries_staticagent.message.Message.name"><code class="name">var <span class="ident">name</span> : str</code></dt>
 <dd>
-<section class="desc"><p>Get type name</p></section>
+<div class="desc"><p>Get type name</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -356,9 +368,9 @@ def name(self) -&gt; str:
     return self._type.name</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.message.Message.normalized_version"><code class="name">var <span class="ident">normalized_version</span></code></dt>
+<dt id="aries_staticagent.message.Message.normalized_version"><code class="name">var <span class="ident">normalized_version</span> : str</code></dt>
 <dd>
-<section class="desc"><p>Get type normalized version</p></section>
+<div class="desc"><p>Get type normalized version</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -369,9 +381,9 @@ def normalized_version(self) -&gt; str:
     return str(self._type.version_info)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.message.Message.protocol"><code class="name">var <span class="ident">protocol</span></code></dt>
+<dt id="aries_staticagent.message.Message.protocol"><code class="name">var <span class="ident">protocol</span> : str</code></dt>
 <dd>
-<section class="desc"><p>Get type protocol</p></section>
+<div class="desc"><p>Get type protocol</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -382,9 +394,22 @@ def protocol(self) -&gt; str:
     return self._type.protocol</code></pre>
 </details>
 </dd>
+<dt id="aries_staticagent.message.Message.thread"><code class="name">var <span class="ident">thread</span></code></dt>
+<dd>
+<div class="desc"><p>Shortcut to msg['~thread'], if present.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def thread(self):
+    &#34;&#34;&#34;Shortcut to msg[&#39;~thread&#39;], if present.&#34;&#34;&#34;
+    return self.get(&#39;~thread&#39;, {&#39;thid&#39;: None})</code></pre>
+</details>
+</dd>
 <dt id="aries_staticagent.message.Message.type"><code class="name">var <span class="ident">type</span></code></dt>
 <dd>
-<section class="desc"><p>Shortcut for msg['@type']</p></section>
+<div class="desc"><p>Shortcut for msg['@type']</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -395,9 +420,9 @@ def type(self):
     return self[&#39;@type&#39;]</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.message.Message.version"><code class="name">var <span class="ident">version</span></code></dt>
+<dt id="aries_staticagent.message.Message.version"><code class="name">var <span class="ident">version</span> : str</code></dt>
 <dd>
-<section class="desc"><p>Get type version</p></section>
+<div class="desc"><p>Get type version</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -408,9 +433,9 @@ def version(self) -&gt; str:
     return self._type.version</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.message.Message.version_info"><code class="name">var <span class="ident">version_info</span></code></dt>
+<dt id="aries_staticagent.message.Message.version_info"><code class="name">var <span class="ident">version_info</span> : <a title="aries_staticagent.type.Semver" href="type.html#aries_staticagent.type.Semver">Semver</a></code></dt>
 <dd>
-<section class="desc"><p>Get type version info</p></section>
+<div class="desc"><p>Get type version info</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -425,10 +450,10 @@ def version_info(self) -&gt; Semver:
 <h3>Methods</h3>
 <dl>
 <dt id="aries_staticagent.message.Message.pretty_print"><code class="name flex">
-<span>def <span class="ident">pretty_print</span></span>(<span>self)</span>
+<span>def <span class="ident">pretty_print</span></span>(<span>self) ‑> str</span>
 </code></dt>
 <dd>
-<section class="desc"><p>return a 'pretty print' representation of this message.</p></section>
+<div class="desc"><p>return a 'pretty print' representation of this message.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -439,10 +464,10 @@ def version_info(self) -&gt; Semver:
 </details>
 </dd>
 <dt id="aries_staticagent.message.Message.serialize"><code class="name flex">
-<span>def <span class="ident">serialize</span></span>(<span>self)</span>
+<span>def <span class="ident">serialize</span></span>(<span>self) ‑> str</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Serialize a message into a json string.</p></section>
+<div class="desc"><p>Serialize a message into a json string.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -490,6 +515,7 @@ def version_info(self) -&gt; Semver:
 <li><code><a title="aries_staticagent.message.Message.pretty_print" href="#aries_staticagent.message.Message.pretty_print">pretty_print</a></code></li>
 <li><code><a title="aries_staticagent.message.Message.protocol" href="#aries_staticagent.message.Message.protocol">protocol</a></code></li>
 <li><code><a title="aries_staticagent.message.Message.serialize" href="#aries_staticagent.message.Message.serialize">serialize</a></code></li>
+<li><code><a title="aries_staticagent.message.Message.thread" href="#aries_staticagent.message.Message.thread">thread</a></code></li>
 <li><code><a title="aries_staticagent.message.Message.type" href="#aries_staticagent.message.Message.type">type</a></code></li>
 <li><code><a title="aries_staticagent.message.Message.version" href="#aries_staticagent.message.Message.version">version</a></code></li>
 <li><code><a title="aries_staticagent.message.Message.version_info" href="#aries_staticagent.message.Message.version_info">version_info</a></code></li>
@@ -501,9 +527,7 @@ def version_info(self) -&gt; Semver:
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/module.html
+++ b/docs/aries_staticagent/module.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.module API documentation</title>
 <meta name="description" content="Module base class" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -197,9 +199,9 @@ def route(*args, **kwargs):
 <span>def <span class="ident">route</span></span>(<span>*args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Route definition decorator
+<div class="desc"><p>Route definition decorator
 if just @route is used, type_or_func is the decorated function
-if @route(type) is used, type_or_func is the type string.</p></section>
+if @route(type) is used, type_or_func is the type string.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -256,10 +258,10 @@ if @route(type) is used, type_or_func is the type string.</p></section>
 <dl>
 <dt id="aries_staticagent.module.InvalidModule"><code class="flex name class">
 <span>class <span class="ident">InvalidModule</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>...)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Thrown when module is malformed.</p></section>
+<div class="desc"><p>Thrown when module is malformed.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -275,11 +277,11 @@ if @route(type) is used, type_or_func is the type string.</p></section>
 </dd>
 <dt id="aries_staticagent.module.MetaModule"><code class="flex name class">
 <span>class <span class="ident">MetaModule</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>name, bases, dct)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>MetaModule:
-Ensures Module classes are well formed and provides convenience methods</p></section>
+<div class="desc"><p>MetaModule:
+Ensures Module classes are well formed and provides convenience methods</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -307,7 +309,7 @@ Ensures Module classes are well formed and provides convenience methods</p></sec
 <span>class <span class="ident">Module</span></span>
 </code></dt>
 <dd>
-<section class="desc"><p>Base Module class</p></section>
+<div class="desc"><p>Base Module class</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -368,23 +370,23 @@ Ensures Module classes are well formed and provides convenience methods</p></sec
 <dl>
 <dt id="aries_staticagent.module.Module.DOC_URI"><code class="name">var <span class="ident">DOC_URI</span></code></dt>
 <dd>
-<section class="desc"></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.module.Module.PROTOCOL"><code class="name">var <span class="ident">PROTOCOL</span></code></dt>
 <dd>
-<section class="desc"></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.module.Module.VERSION"><code class="name">var <span class="ident">VERSION</span></code></dt>
 <dd>
-<section class="desc"></section>
+<div class="desc"></div>
 </dd>
 </dl>
 <h3>Instance variables</h3>
 <dl>
 <dt id="aries_staticagent.module.Module.routes"><code class="name">var <span class="ident">routes</span></code></dt>
 <dd>
-<section class="desc"><p>Get the routes statically defined for this module and
-save in instance.</p></section>
+<div class="desc"><p>Get the routes statically defined for this module and
+save in instance.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -403,10 +405,10 @@ def routes(self):
 <h3>Methods</h3>
 <dl>
 <dt id="aries_staticagent.module.Module.type"><code class="name flex">
-<span>def <span class="ident">type</span></span>(<span>self, name, doc_uri=None, protocol=None, version=None)</span>
+<span>def <span class="ident">type</span></span>(<span>self, name: str, doc_uri: str = None, protocol: str = None, version: str = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Build a type string for this module.</p></section>
+<div class="desc"><p>Build a type string for this module.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -435,12 +437,12 @@ def routes(self):
 </dd>
 <dt id="aries_staticagent.module.PartialType"><code class="flex name class">
 <span>class <span class="ident">PartialType</span></span>
-<span>(</span><span>name, doc_uri=None, protocol=None, version=None)</span>
+<span>(</span><span>name: str, doc_uri: str = None, protocol: str = None, version: str = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Class containing the type information of a route before having the
+<div class="desc"><p>Class containing the type information of a route before having the
 context of the module as is the case when statically defining routes in
-a module definition.</p></section>
+a module definition.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -486,28 +488,28 @@ a module definition.</p></section>
 <dl>
 <dt id="aries_staticagent.module.PartialType.doc_uri"><code class="name">var <span class="ident">doc_uri</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.module.PartialType.name"><code class="name">var <span class="ident">name</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.module.PartialType.protocol"><code class="name">var <span class="ident">protocol</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.module.PartialType.version"><code class="name">var <span class="ident">version</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 </dl>
 <h3>Methods</h3>
 <dl>
 <dt id="aries_staticagent.module.PartialType.complete"><code class="name flex">
-<span>def <span class="ident">complete</span></span>(<span>self, mod)</span>
+<span>def <span class="ident">complete</span></span>(<span>self, mod: <a title="aries_staticagent.module.Module" href="#aries_staticagent.module.Module">Module</a>) ‑> <a title="aries_staticagent.type.Type" href="type.html#aries_staticagent.type.Type">Type</a></span>
 </code></dt>
 <dd>
-<section class="desc"><p>Return a complete type given the module context.</p></section>
+<div class="desc"><p>Return a complete type given the module context.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -581,9 +583,7 @@ a module definition.</p></section>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/mtc.html
+++ b/docs/aries_staticagent/mtc.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.mtc API documentation</title>
 <meta name="description" content="Message Trust Context. See Aries RFC 0029: Message Trust Contexts …" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -32,9 +34,8 @@ that RFC.</p>
     This file is inspired by the example implementation contained within
     that RFC.
 &#34;&#34;&#34;
-from collections import namedtuple
 from enum import Flag, auto
-from typing import Optional, TypeVar
+from typing import Optional
 
 
 class ContextsConflict(Exception):
@@ -244,10 +245,10 @@ class MessageTrustContext:
 <dl>
 <dt id="aries_staticagent.mtc.AdditionalData"><code class="flex name class">
 <span>class <span class="ident">AdditionalData</span></span>
-<span>(</span><span>sender=None, recipient=None)</span>
+<span>(</span><span>sender: str = None, recipient: str = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Container for data relevant to Message Trust.</p></section>
+<div class="desc"><p>Container for data relevant to Message Trust.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -266,20 +267,20 @@ class MessageTrustContext:
 <dl>
 <dt id="aries_staticagent.mtc.AdditionalData.recipient"><code class="name">var <span class="ident">recipient</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.mtc.AdditionalData.sender"><code class="name">var <span class="ident">sender</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 </dl>
 </dd>
 <dt id="aries_staticagent.mtc.Context"><code class="flex name class">
 <span>class <span class="ident">Context</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>value, names=None, *, module=None, qualname=None, type=None, start=1)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"><p>Flags for MTC</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -308,60 +309,60 @@ class MessageTrustContext:
 <dl>
 <dt id="aries_staticagent.mtc.Context.AUTHENTICATED_ORIGIN"><code class="name">var <span class="ident">AUTHENTICATED_ORIGIN</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.CONFIDENTIALITY"><code class="name">var <span class="ident">CONFIDENTIALITY</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.DESERIALIZE_OK"><code class="name">var <span class="ident">DESERIALIZE_OK</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.INTEGRITY"><code class="name">var <span class="ident">INTEGRITY</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.KEYS_OK"><code class="name">var <span class="ident">KEYS_OK</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.LIMITED_SCOPE"><code class="name">var <span class="ident">LIMITED_SCOPE</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.NONE"><code class="name">var <span class="ident">NONE</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.NONREPUDIATION"><code class="name">var <span class="ident">NONREPUDIATION</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.PFS"><code class="name">var <span class="ident">PFS</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.SIZE_OK"><code class="name">var <span class="ident">SIZE_OK</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.UNIQUENESS"><code class="name">var <span class="ident">UNIQUENESS</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 <dt id="aries_staticagent.mtc.Context.VALUES_OK"><code class="name">var <span class="ident">VALUES_OK</span></code></dt>
 <dd>
-<section class="desc"><p>Flags for MTC</p></section>
+<div class="desc"></div>
 </dd>
 </dl>
 </dd>
 <dt id="aries_staticagent.mtc.ContextsConflict"><code class="flex name class">
 <span>class <span class="ident">ContextsConflict</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>...)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Thrown when the passed contexts overlap</p></section>
+<div class="desc"><p>Thrown when the passed contexts overlap</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -377,13 +378,13 @@ class MessageTrustContext:
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext"><code class="flex name class">
 <span>class <span class="ident">MessageTrustContext</span></span>
-<span>(</span><span>affirmed=Context.NONE, denied=Context.NONE, additional_data=None)</span>
+<span>(</span><span>affirmed: <a title="aries_staticagent.mtc.Context" href="#aries_staticagent.mtc.Context">Context</a> = Context.NONE, denied: <a title="aries_staticagent.mtc.Context" href="#aries_staticagent.mtc.Context">Context</a> = Context.NONE, additional_data: <a title="aries_staticagent.mtc.AdditionalData" href="#aries_staticagent.mtc.AdditionalData">AdditionalData</a> = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Message Trust Context</p>
+<div class="desc"><p>Message Trust Context</p>
 <p>Holds the contexts as well as data associated with message trust
 contexts such as the keys used to encrypt the message and allowing us
-to know that the origin is authenticated, etc.</p></section>
+to know that the origin is authenticated, etc.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -513,11 +514,11 @@ to know that the origin is authenticated, etc.</p></section>
 <dl>
 <dt id="aries_staticagent.mtc.MessageTrustContext.additional_data"><code class="name">var <span class="ident">additional_data</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext.affirmed"><code class="name">var <span class="ident">affirmed</span></code></dt>
 <dd>
-<section class="desc"><p>Access affirmed contexts</p></section>
+<div class="desc"><p>Access affirmed contexts</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -530,7 +531,7 @@ def affirmed(self):
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext.denied"><code class="name">var <span class="ident">denied</span></code></dt>
 <dd>
-<section class="desc"><p>Access denied contexts</p></section>
+<div class="desc"><p>Access denied contexts</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -543,7 +544,7 @@ def denied(self):
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext.recipient"><code class="name">var <span class="ident">recipient</span></code></dt>
 <dd>
-<section class="desc"><p>Shortcut to recipient.</p></section>
+<div class="desc"><p>Shortcut to recipient.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -556,7 +557,7 @@ def recipient(self):
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext.sender"><code class="name">var <span class="ident">sender</span></code></dt>
 <dd>
-<section class="desc"><p>Shortcut to sender.</p></section>
+<div class="desc"><p>Shortcut to sender.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -574,7 +575,7 @@ def sender(self):
 <span>def <span class="ident">is_anoncrypted</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>MTC matches expected anoncrypt.</p></section>
+<div class="desc"><p>MTC matches expected anoncrypt.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -589,7 +590,7 @@ def sender(self):
 <span>def <span class="ident">is_authcrypted</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>MTC matches expected authcrypt.</p></section>
+<div class="desc"><p>MTC matches expected authcrypt.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -604,7 +605,7 @@ def sender(self):
 <span>def <span class="ident">is_plaintext</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>MTC matches expected plaintext.</p></section>
+<div class="desc"><p>MTC matches expected plaintext.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -616,10 +617,10 @@ def sender(self):
 </details>
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext.set_anoncrypted"><code class="name flex">
-<span>def <span class="ident">set_anoncrypted</span></span>(<span>self, recipient)</span>
+<span>def <span class="ident">set_anoncrypted</span></span>(<span>self, recipient: str)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set MTC to match anoncrypt.</p></section>
+<div class="desc"><p>Set MTC to match anoncrypt.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -633,10 +634,10 @@ def sender(self):
 </details>
 </dd>
 <dt id="aries_staticagent.mtc.MessageTrustContext.set_authcrypted"><code class="name flex">
-<span>def <span class="ident">set_authcrypted</span></span>(<span>self, sender, recipient)</span>
+<span>def <span class="ident">set_authcrypted</span></span>(<span>self, sender: str, recipient: str)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set MTC to match authcrypt.</p></section>
+<div class="desc"><p>Set MTC to match authcrypt.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -653,7 +654,7 @@ def sender(self):
 <span>def <span class="ident">set_plaintext</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set MTC to match plaintext.</p></section>
+<div class="desc"><p>Set MTC to match plaintext.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -733,9 +734,7 @@ def sender(self):
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/static_connection.html
+++ b/docs/aries_staticagent/static_connection.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.static_connection API documentation</title>
 <meta name="description" content="Static Agent Connection." />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -31,9 +33,10 @@ import json
 from contextlib import contextmanager
 from typing import (
     Union, Callable, Awaitable, Dict,
-    Tuple, Sequence, Optional, List
+    Tuple, Sequence, Optional, List,
+    Set
 )
-from collections import namedtuple
+import uuid
 
 from . import crypto
 from .dispatcher import Dispatcher, Handler
@@ -45,7 +48,7 @@ from .utils import ensure_key_bytes, forward_msg, http_send
 
 
 Send = Callable[[bytes, str], Awaitable[Optional[bytes]]]
-Reply = Callable[[bytes], Awaitable[None]]
+SessionSend = Callable[[bytes], Awaitable[None]]
 ConditionFutureMap = Dict[Callable[[Message], bool], asyncio.Future]
 
 
@@ -56,7 +59,194 @@ class MessageDeliveryError(Exception):
         self.status = status
 
 
-class StaticConnection:
+class Session:
+    &#34;&#34;&#34;An active transport-layer connection/socket providing a send method.&#34;&#34;&#34;
+
+    THREAD_ALL = &#39;all&#39;
+
+    def __init__(self, send: SessionSend, thread: str = None):
+        if send is None:
+            raise TypeError(&#39;Must supply send method to Session&#39;)
+
+        if not callable(send) and not asyncio.iscoroutine(send):
+            raise TypeError(
+                &#39;Invalid send method; expected coroutine or function, got {}&#39;
+                .format(type(send).__name__)
+            )
+
+        self._id = str(uuid.uuid4())
+        self._send = send
+        self._thread = thread
+        self._status = None
+
+    @property
+    def session_id(self):
+        &#34;&#34;&#34;Unique Identifier for this session.&#34;&#34;&#34;
+        return self._id
+
+    @property
+    def thread(self):
+        &#34;&#34;&#34;Get this session&#39;s assigned thread.&#34;&#34;&#34;
+        return self._thread
+
+    def update_thread_from_msg(self, msg: Message):
+        &#34;&#34;&#34;Update a thread with info from the ~transport decorator.&#34;&#34;&#34;
+        if &#39;~transport&#39; not in msg and self._thread is None:
+            return
+
+        transport = msg[&#39;~transport&#39;]
+        if transport[&#39;return_route&#39;] == &#39;all&#39;:
+            self._thread = self.THREAD_ALL
+            return
+
+        if transport[&#39;return_route&#39;] == &#39;thread&#39;:
+            self._thread = transport[&#39;return_route_thread&#39;]
+            return
+
+        if transport[&#39;return_route&#39;] == &#39;none&#39;:
+            self._thread = None
+            return
+
+    def returning(self) -&gt; bool:
+        &#34;&#34;&#34;Session set to return route?&#34;&#34;&#34;
+        return bool(self._thread)
+
+    def thread_all(self) -&gt; bool:
+        &#34;&#34;&#34;Session is set to return all messages.&#34;&#34;&#34;
+        return self.thread == self.THREAD_ALL
+
+    async def send(self, message: bytes):
+        &#34;&#34;&#34;Send a packed message to this session.&#34;&#34;&#34;
+        if not self.returning():
+            raise RuntimeError(&#39;Session is not set to return route&#39;)
+
+        ret = self._send(message)
+        if asyncio.iscoroutine(ret):
+            return await ret
+
+        return ret
+
+    def __hash__(self):
+        return hash(self.session_id)
+
+    def __eq__(self, other):
+        if not isinstance(other, Session):
+            return False
+        return self.session_id == other.session_id
+
+
+class Keys:
+    Key = Union[bytes, str]
+
+    &#34;&#34;&#34;Container for keys with convenience methods.&#34;&#34;&#34;
+    class Mixin:
+        &#34;&#34;&#34;Mixin for shortcuts to keys.&#34;&#34;&#34;
+        def __init__(self, keys: &#39;Keys&#39;):
+            self.keys = keys
+
+        @property
+        def verkey(self):
+            &#34;&#34;&#34;Get verkey.&#34;&#34;&#34;
+            return self.keys.verkey
+
+        @property
+        def verkey_b58(self):
+            &#34;&#34;&#34;Get Base58 encoded verkey.&#34;&#34;&#34;
+            return self.keys.verkey_b58
+
+        @property
+        def sigkey(self):
+            &#34;&#34;&#34;Get sigkey.&#34;&#34;&#34;
+            return self.keys.sigkey
+
+        @property
+        def did(self):
+            &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
+            return self.keys.did
+
+    def __init__(self, verkey: Key, sigkey: Key):
+        self._verkey = ensure_key_bytes(verkey)
+        self._sigkey = ensure_key_bytes(sigkey)
+
+    @property
+    def verkey(self):
+        &#34;&#34;&#34;Get verkey.&#34;&#34;&#34;
+        return self._verkey
+
+    @property
+    def verkey_b58(self):
+        &#34;&#34;&#34;Get Base58 encoded verkey.&#34;&#34;&#34;
+        return crypto.bytes_to_b58(self.verkey)
+
+    @property
+    def sigkey(self):
+        &#34;&#34;&#34;Get sigkey.&#34;&#34;&#34;
+        return self._sigkey
+
+    @property
+    def did(self):
+        &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
+        return crypto.bytes_to_b58(self._verkey[:16])
+
+    def __str__(self):
+        return &#34;Keys({}, {}...)&#34;.format(
+            self.verkey_b58, crypto.bytes_to_b58(self.sigkey)[:10]
+        )
+
+
+class Target:
+    &#34;&#34;&#34;Container for information about our message destination.&#34;&#34;&#34;
+    def __init__(
+            self,
+            *,
+            endpoint: str = None,
+            their_vk: Union[bytes, str] = None,
+            recipients: Sequence[Union[bytes, str]] = None,
+            routing_keys: Sequence[Union[bytes, str]] = None
+    ):
+        if their_vk and recipients:
+            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+
+        self.endpoint: Optional[str] = endpoint
+        self.recipients: Optional[List[bytes]] = None
+        self.routing_keys: Optional[List[bytes]] = None
+
+        if their_vk:
+            self.recipients = [ensure_key_bytes(their_vk)]
+
+        if recipients:
+            self.recipients = list(map(ensure_key_bytes, recipients))
+
+        if routing_keys:
+            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
+
+    def update(
+            self,
+            *,
+            endpoint: str = None,
+            their_vk: Union[bytes, str] = None,
+            recipients: Sequence[Union[bytes, str]] = None,
+            routing_keys: Sequence[Union[bytes, str]] = None,
+            **_kwargs
+    ):
+        &#34;&#34;&#34;Update their information.&#34;&#34;&#34;
+        if their_vk and recipients:
+            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+
+        if endpoint:
+            self.endpoint = endpoint
+
+        if their_vk:
+            self.recipients = [ensure_key_bytes(their_vk)]
+
+        if recipients:
+            self.recipients = list(map(ensure_key_bytes, recipients))
+
+        if routing_keys:
+            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
+
+
+class StaticConnection(Keys.Mixin):
     &#34;&#34;&#34;Create a Static Agent Connection to another agent.
 
     The following will create a Static Connection with just the receiving end
@@ -64,28 +254,26 @@ class StaticConnection:
     without yet knowing where messages will be sent.
 
     &gt;&gt;&gt; my_keys = crypto.create_keypair()
-    &gt;&gt;&gt; connection = StaticConnection(my_keys)
+    &gt;&gt;&gt; connection = StaticConnection.receiver(my_keys)
 
     To create a Static Agent Connection with both ends configured:
     &gt;&gt;&gt; their_pretend_verkey = crypto.create_keypair()[0]
-    &gt;&gt;&gt; connection = StaticConnection(my_keys, their_vk=their_pretend_verkey)
-    &gt;&gt;&gt; connection.recipients == [their_pretend_verkey]
-    True
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
+    ...     my_keys, their_vk=their_pretend_verkey
+    ... )
 
     Or, when there are multiple recipients:
     &gt;&gt;&gt; pretend_recips = [ crypto.create_keypair()[0] for i in range(5) ]
-    &gt;&gt;&gt; connection = StaticConnection(my_keys, recipients=pretend_recips)
-    &gt;&gt;&gt; connection.recipients == pretend_recips
-    True
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
+    ...     my_keys, recipients=pretend_recips
+    ... )
 
     To specify mediators responsible for forwarding messages to the recipient:
     &gt;&gt;&gt; pretend_mediators = [ crypto.create_keypair()[0] for i in range(5) ]
-    &gt;&gt;&gt; connection = StaticConnection(
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
     ...     my_keys, their_vk=their_pretend_verkey,
     ...     routing_keys=pretend_mediators
     ... )
-    &gt;&gt;&gt; connection.routing_keys == pretend_mediators
-    True
 
     By default, `StaticConnection` will POST messages to the endpoint given
     over HTTP. You can, however, specify an alternative `Send` method for
@@ -94,7 +282,7 @@ class StaticConnection:
     ...     print(&#39;pretending to send message to&#39;, endpoint)
     ...     response = None
     ...     return response
-    &gt;&gt;&gt; connection = StaticConnection(
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
     ...     my_keys, their_vk=their_pretend_verkey,
     ...     endpoint=&#39;example.com&#39;, send=my_send
     ... )
@@ -127,84 +315,106 @@ class StaticConnection:
             `aries_staticagent.dispatcher.Dispatcher`.
     &#34;&#34;&#34;
 
-    Keys = namedtuple(&#39;KeyPair&#39;, &#39;verkey, sigkey&#39;)
-
     def __init__(
             self,
-            keys: Tuple[Union[bytes, str], Union[bytes, str]],
+            keys: Keys,
+            target: Target = None,
             *,
-            endpoint: str = None,
-            their_vk: Union[bytes, str] = None,
-            recipients: Sequence[Union[bytes, str]] = None,
-            routing_keys: Sequence[Union[bytes, str]] = None,
+            modules: Sequence[Union[Module, type]] = None,
             send: Send = None,
-            dispatcher: Dispatcher = None):
+            dispatcher: Dispatcher = None
+    ):
 
-        if their_vk and recipients:
-            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+        Keys.Mixin.__init__(self, keys)
+        self.target = target
 
-        self.keys = StaticConnection.Keys(*map(ensure_key_bytes, keys))
-        self.endpoint: Optional[str] = endpoint
-        self.recipients: Optional[List[bytes]] = None
-        self.routing_keys: Optional[List[bytes]] = None
+        if modules:
+            for mod in modules:
+                if isinstance(mod, type):  # attempt to instantiate module
+                    mod = mod()
+                self.route_module(mod)
 
-        if their_vk:
-            self.recipients = [ensure_key_bytes(their_vk)]
-
-        if recipients:
-            self.recipients = list(map(ensure_key_bytes, recipients))
-
-        if routing_keys:
-            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
-
-        self._dispatcher = dispatcher if dispatcher else Dispatcher()
-        self._next: ConditionFutureMap = {}
-        self._reply: Optional[Reply] = None
         self._send: Send = send if send else http_send
+        self._dispatcher = dispatcher if dispatcher else Dispatcher()
 
-    def update(
-            self,
+        self._next: ConditionFutureMap = {}
+        self._sessions: Set[Session] = set()
+
+    @classmethod
+    def from_parts(
+            cls,
+            keys: Union[Keys, Tuple[Keys.Key, Keys.Key]],
             *,
             endpoint: str = None,
             their_vk: Union[bytes, str] = None,
             recipients: Sequence[Union[bytes, str]] = None,
             routing_keys: Sequence[Union[bytes, str]] = None,
-            **_kwargs):
-        &#34;&#34;&#34;Update their information.&#34;&#34;&#34;
-        if their_vk and recipients:
-            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+            **kwargs
+    ):
+        &#34;&#34;&#34;Construct a static connection from its parts.
 
-        if endpoint:
-            self.endpoint = endpoint
+        Arguments:
 
-        if their_vk:
-            self.recipients = [ensure_key_bytes(their_vk)]
+            keys (tuple of bytes or str): A tuple of our public and private
+            key.
 
-        if recipients:
-            self.recipients = list(map(ensure_key_bytes, recipients))
+        NamedArguments:
 
-        if routing_keys:
-            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
+            their_vk (bytes or str): Specify &#34;their&#34; verification key for this
+                connection. Specifies only one recipient. Mutually exclusive
+                with recipients.
 
-    @property
-    def verkey(self):
-        &#34;&#34;&#34;My verification key for this connection.&#34;&#34;&#34;
-        return self.keys.verkey
+            recipients ([bytes or str]): Specify one or more recipients for
+                this connection. Mutually exclusive with their_vk.
 
-    @property
-    def verkey_b58(self):
-        &#34;&#34;&#34;Get Base58 encoded my_vk.&#34;&#34;&#34;
-        return crypto.bytes_to_b58(self.keys.verkey)
+            routing_keys ([bytes or str]): Specify one or more mediators for
+                this connection.
 
-    @property
-    def sigkey(self):
-        &#34;&#34;&#34;My signing key for this connection.&#34;&#34;&#34;
-        return self.keys.sigkey
+            send (Send): Specify the send method for this connection. See notes
+                above for function signature.  Defaults to
+                `aries_staticagent.utils.http_send`.
 
-    @property
-    def did(self):
-        &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
-        return crypto.bytes_to_b58(self.keys.verkey[:16])
+            dispatcher (aries_staticagent.dispatcher.Dispatcher): Specify a
+                dispatcher for this connection.  Defaults to
+                `aries_staticagent.dispatcher.Dispatcher`.
+        &#34;&#34;&#34;
+        if not isinstance(keys, Keys):
+            keys = Keys(*keys)
+        target = None
+        if endpoint or their_vk or recipients or routing_keys:
+            target = Target(
+                endpoint=endpoint,
+                their_vk=their_vk,
+                recipients=recipients,
+                routing_keys=routing_keys
+            )
+        return cls(keys, target, **kwargs)
+
+    @classmethod
+    def receiver(
+            cls,
+            keys: Union[Keys, Tuple[Keys.Key, Keys.Key]],
+            **kwargs
+    ):
+        &#34;&#34;&#34;Create a static connection to be used only for receiving messages.
+
+        Arguments:
+
+            keys (Keys or Tuple of keys): Our public and private keys.
+        &#34;&#34;&#34;
+        if not isinstance(keys, Keys):
+            keys = Keys(*keys)
+        return cls(keys, **kwargs)
+
+    @classmethod
+    def random(cls, target: Target = None, **kwargs):
+        &#34;&#34;&#34;Generate connection with random keys.&#34;&#34;&#34;
+        return cls(Keys(*crypto.create_keypair()), target, **kwargs)
+
+    @classmethod
+    def from_seed(cls, seed: str, target: Target = None, **kwargs):
+        &#34;&#34;&#34;Generate connection from seed.&#34;&#34;&#34;
+        return cls(Keys(*crypto.create_keypair(seed=seed)), target, **kwargs)
 
     def route(self, msg_type: str) -&gt; Callable:
         &#34;&#34;&#34;Register route decorator.&#34;&#34;&#34;
@@ -319,62 +529,72 @@ class StaticConnection:
         if plaintext:
             return json.dumps(msg).encode(&#39;ascii&#39;)
 
-        if not self.recipients:
+        if not self.target or not self.target.recipients:
             raise RuntimeError(&#39;No recipients for whom to pack this message&#39;)
 
         if anoncrypt:
             packed_message = crypto.pack_message(
                 msg.serialize(),
-                self.recipients,
+                self.target.recipients,
             )
         else:
             packed_message = crypto.pack_message(
                 msg.serialize(),
-                self.recipients,
+                self.target.recipients,
                 self.verkey,
                 self.sigkey,
             )
 
-        if self.routing_keys:
-            to = self.recipients[0]
-            for routing_key in self.routing_keys:
+        if self.target.routing_keys:
+            forward_to = self.target.recipients[0]
+            for routing_key in self.target.routing_keys:
                 packed_message = crypto.pack_message(
-                    forward_msg(to=to, msg=packed_message).serialize(),
+                    forward_msg(to=forward_to, msg=packed_message).serialize(),
                     [routing_key],
                 )
-                to = routing_key
+                forward_to = routing_key
 
         return json.dumps(packed_message).encode(&#39;ascii&#39;)
 
     @contextmanager
-    def reply_handler(
+    def session(self, send: SessionSend):
+        &#34;&#34;&#34;Open a new session for this connection.&#34;&#34;&#34;
+
+        session = Session(send)
+        self._sessions.add(session)
+        yield session
+        self._sessions.remove(session)
+
+    def session_open(self) -&gt; bool:
+        &#34;&#34;&#34;Check whether connection has sessions open.&#34;&#34;&#34;
+        return bool(self._sessions)
+
+    async def send_to_session(
             self,
-            reply: Reply):
-        &#34;&#34;&#34;
-        Set a reply handler to be used in sending messages rather than opening
-        a new connection.
-        &#34;&#34;&#34;
-        self._reply = reply
-        yield
-        self._reply = None
+            message: bytes,
+            thread: str = None
+    ) -&gt; bool:
+        &#34;&#34;&#34;Send a message to all sessions with a matching thread.&#34;&#34;&#34;
+        if not self._sessions:
+            raise RuntimeError(
+                &#39;Cannot send message to session; no open sessions&#39;
+            )
 
-    def can_reply(self) -&gt; bool:
-        &#34;&#34;&#34;Check whether connection can reply.&#34;&#34;&#34;
-        return self._reply is not None
+        sent = False
+        for session in self._sessions:
+            if not session.returning():
+                continue
 
-    async def reply(self, message: bytes):
-        &#34;&#34;&#34;Call reply method.&#34;&#34;&#34;
-        if self._reply is None:
-            raise RuntimeError(&#39;Cannot reply; no reply handler is set&#39;)
-        await self._reply(message)
+            if session.thread == thread or session.thread_all():
+                await session.send(message)
+                sent = True
+        return sent
 
-    async def handle(self, packed_message: bytes):
+    async def handle(self, packed_message: bytes, session: Session = None):
         &#34;&#34;&#34;Unpack and dispatch message to handler.&#34;&#34;&#34;
         msg = self.unpack(packed_message)
-        if (&#39;~transport&#39; not in msg or
-                &#39;return_route&#39; not in msg[&#39;~transport&#39;] or
-                msg[&#39;~transport&#39;][&#39;return_route&#39;] == &#39;none&#39;):
-            self._reply = None
+        if session:
+            session.update_thread_from_msg(msg)
 
         for condition, next_message_future in self._next.items():
             if condition(msg) and not next_message_future.done():
@@ -393,8 +613,14 @@ class StaticConnection:
         &#34;&#34;&#34;
         Send a message to the agent connected through this StaticConnection.
         &#34;&#34;&#34;
-        # not can_reply indicates this is an outbound message
-        if return_route and not self.can_reply():
+        if not isinstance(msg, Message):
+            if isinstance(msg, dict):
+                msg = Message(msg)
+            else:
+                raise TypeError(&#39;msg must be type Message or dict&#39;)
+
+        # TODO: Don&#39;t specify return route on messages sent to sessions?
+        if return_route:
             if &#39;~transport&#39; not in msg:
                 msg[&#39;~transport&#39;] = {}
             msg[&#39;~transport&#39;][&#39;return_route&#39;] = return_route
@@ -403,11 +629,11 @@ class StaticConnection:
             msg, anoncrypt=anoncrypt, plaintext=plaintext
         )
 
-        if self.can_reply():
-            await self.reply(packed_message)
-            return
+        if self.session_open():
+            if await self.send_to_session(packed_message, msg.thread[&#39;thid&#39;]):
+                return
 
-        if not self.endpoint:
+        if not self.target or not self.target.endpoint:
             raise MessageDeliveryError(
                 msg=&#39;Cannot send message; no endpoint and no return route.&#39;
             )
@@ -415,7 +641,7 @@ class StaticConnection:
         try:
             response = await self._send(
                 packed_message,
-                self.endpoint
+                self.target.endpoint
             )
         except Exception as err:
             raise MessageDeliveryError(msg=str(err)) from err
@@ -436,7 +662,8 @@ class StaticConnection:
             return_route: str = &#34;all&#34;,
             plaintext: bool = False,
             anoncrypt: bool = False,
-            timeout: int = None) -&gt; Message:
+            timeout: int = None
+    ) -&gt; Message:
         &#34;&#34;&#34;Send a message and wait for a reply.&#34;&#34;&#34;
 
         with self.next(type_=type_, condition=condition) as next_message:
@@ -453,7 +680,8 @@ class StaticConnection:
             *,
             type_: str = None,
             condition: Callable[[Message], bool] = None,
-            timeout: int = None):
+            timeout: int = None
+    ):
         &#34;&#34;&#34;
         Wait for a message.
 
@@ -487,12 +715,147 @@ class StaticConnection:
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
 <dl>
-<dt id="aries_staticagent.static_connection.MessageDeliveryError"><code class="flex name class">
-<span>class <span class="ident">MessageDeliveryError</span></span>
-<span>(</span><span>*, status=None, msg=None)</span>
+<dt id="aries_staticagent.static_connection.Keys"><code class="flex name class">
+<span>class <span class="ident">Keys</span></span>
+<span>(</span><span>verkey: Union[bytes, str], sigkey: Union[bytes, str])</span>
 </code></dt>
 <dd>
-<section class="desc"><p>When a message cannot be delivered.</p></section>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Keys:
+    Key = Union[bytes, str]
+
+    &#34;&#34;&#34;Container for keys with convenience methods.&#34;&#34;&#34;
+    class Mixin:
+        &#34;&#34;&#34;Mixin for shortcuts to keys.&#34;&#34;&#34;
+        def __init__(self, keys: &#39;Keys&#39;):
+            self.keys = keys
+
+        @property
+        def verkey(self):
+            &#34;&#34;&#34;Get verkey.&#34;&#34;&#34;
+            return self.keys.verkey
+
+        @property
+        def verkey_b58(self):
+            &#34;&#34;&#34;Get Base58 encoded verkey.&#34;&#34;&#34;
+            return self.keys.verkey_b58
+
+        @property
+        def sigkey(self):
+            &#34;&#34;&#34;Get sigkey.&#34;&#34;&#34;
+            return self.keys.sigkey
+
+        @property
+        def did(self):
+            &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
+            return self.keys.did
+
+    def __init__(self, verkey: Key, sigkey: Key):
+        self._verkey = ensure_key_bytes(verkey)
+        self._sigkey = ensure_key_bytes(sigkey)
+
+    @property
+    def verkey(self):
+        &#34;&#34;&#34;Get verkey.&#34;&#34;&#34;
+        return self._verkey
+
+    @property
+    def verkey_b58(self):
+        &#34;&#34;&#34;Get Base58 encoded verkey.&#34;&#34;&#34;
+        return crypto.bytes_to_b58(self.verkey)
+
+    @property
+    def sigkey(self):
+        &#34;&#34;&#34;Get sigkey.&#34;&#34;&#34;
+        return self._sigkey
+
+    @property
+    def did(self):
+        &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
+        return crypto.bytes_to_b58(self._verkey[:16])
+
+    def __str__(self):
+        return &#34;Keys({}, {}...)&#34;.format(
+            self.verkey_b58, crypto.bytes_to_b58(self.sigkey)[:10]
+        )</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="aries_staticagent.static_connection.Keys.Key"><code class="name">var <span class="ident">Key</span></code></dt>
+<dd>
+<div class="desc"><p>Container for keys with convenience methods.</p></div>
+</dd>
+<dt id="aries_staticagent.static_connection.Keys.Mixin"><code class="name">var <span class="ident">Mixin</span></code></dt>
+<dd>
+<div class="desc"><p>Mixin for shortcuts to keys.</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="aries_staticagent.static_connection.Keys.did"><code class="name">var <span class="ident">did</span></code></dt>
+<dd>
+<div class="desc"><p>Get verkey based DID for this connection.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def did(self):
+    &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
+    return crypto.bytes_to_b58(self._verkey[:16])</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Keys.sigkey"><code class="name">var <span class="ident">sigkey</span></code></dt>
+<dd>
+<div class="desc"><p>Get sigkey.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def sigkey(self):
+    &#34;&#34;&#34;Get sigkey.&#34;&#34;&#34;
+    return self._sigkey</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Keys.verkey"><code class="name">var <span class="ident">verkey</span></code></dt>
+<dd>
+<div class="desc"><p>Get verkey.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def verkey(self):
+    &#34;&#34;&#34;Get verkey.&#34;&#34;&#34;
+    return self._verkey</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Keys.verkey_b58"><code class="name">var <span class="ident">verkey_b58</span></code></dt>
+<dd>
+<div class="desc"><p>Get Base58 encoded verkey.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def verkey_b58(self):
+    &#34;&#34;&#34;Get Base58 encoded verkey.&#34;&#34;&#34;
+    return crypto.bytes_to_b58(self.verkey)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="aries_staticagent.static_connection.MessageDeliveryError"><code class="flex name class">
+<span>class <span class="ident">MessageDeliveryError</span></span>
+<span>(</span><span>*, status: int = None, msg: str = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>When a message cannot be delivered.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -509,47 +872,247 @@ class StaticConnection:
 <li>builtins.BaseException</li>
 </ul>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection"><code class="flex name class">
-<span>class <span class="ident">StaticConnection</span></span>
-<span>(</span><span>keys, *, endpoint=None, their_vk=None, recipients=None, routing_keys=None, send=None, dispatcher=None)</span>
+<dt id="aries_staticagent.static_connection.Session"><code class="flex name class">
+<span>class <span class="ident">Session</span></span>
+<span>(</span><span>send: Callable[[bytes], Awaitable[NoneType]], thread: str = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Create a Static Agent Connection to another agent.</p>
+<div class="desc"><p>An active transport-layer connection/socket providing a send method.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Session:
+    &#34;&#34;&#34;An active transport-layer connection/socket providing a send method.&#34;&#34;&#34;
+
+    THREAD_ALL = &#39;all&#39;
+
+    def __init__(self, send: SessionSend, thread: str = None):
+        if send is None:
+            raise TypeError(&#39;Must supply send method to Session&#39;)
+
+        if not callable(send) and not asyncio.iscoroutine(send):
+            raise TypeError(
+                &#39;Invalid send method; expected coroutine or function, got {}&#39;
+                .format(type(send).__name__)
+            )
+
+        self._id = str(uuid.uuid4())
+        self._send = send
+        self._thread = thread
+        self._status = None
+
+    @property
+    def session_id(self):
+        &#34;&#34;&#34;Unique Identifier for this session.&#34;&#34;&#34;
+        return self._id
+
+    @property
+    def thread(self):
+        &#34;&#34;&#34;Get this session&#39;s assigned thread.&#34;&#34;&#34;
+        return self._thread
+
+    def update_thread_from_msg(self, msg: Message):
+        &#34;&#34;&#34;Update a thread with info from the ~transport decorator.&#34;&#34;&#34;
+        if &#39;~transport&#39; not in msg and self._thread is None:
+            return
+
+        transport = msg[&#39;~transport&#39;]
+        if transport[&#39;return_route&#39;] == &#39;all&#39;:
+            self._thread = self.THREAD_ALL
+            return
+
+        if transport[&#39;return_route&#39;] == &#39;thread&#39;:
+            self._thread = transport[&#39;return_route_thread&#39;]
+            return
+
+        if transport[&#39;return_route&#39;] == &#39;none&#39;:
+            self._thread = None
+            return
+
+    def returning(self) -&gt; bool:
+        &#34;&#34;&#34;Session set to return route?&#34;&#34;&#34;
+        return bool(self._thread)
+
+    def thread_all(self) -&gt; bool:
+        &#34;&#34;&#34;Session is set to return all messages.&#34;&#34;&#34;
+        return self.thread == self.THREAD_ALL
+
+    async def send(self, message: bytes):
+        &#34;&#34;&#34;Send a packed message to this session.&#34;&#34;&#34;
+        if not self.returning():
+            raise RuntimeError(&#39;Session is not set to return route&#39;)
+
+        ret = self._send(message)
+        if asyncio.iscoroutine(ret):
+            return await ret
+
+        return ret
+
+    def __hash__(self):
+        return hash(self.session_id)
+
+    def __eq__(self, other):
+        if not isinstance(other, Session):
+            return False
+        return self.session_id == other.session_id</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="aries_staticagent.static_connection.Session.THREAD_ALL"><code class="name">var <span class="ident">THREAD_ALL</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="aries_staticagent.static_connection.Session.session_id"><code class="name">var <span class="ident">session_id</span></code></dt>
+<dd>
+<div class="desc"><p>Unique Identifier for this session.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def session_id(self):
+    &#34;&#34;&#34;Unique Identifier for this session.&#34;&#34;&#34;
+    return self._id</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Session.thread"><code class="name">var <span class="ident">thread</span></code></dt>
+<dd>
+<div class="desc"><p>Get this session's assigned thread.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def thread(self):
+    &#34;&#34;&#34;Get this session&#39;s assigned thread.&#34;&#34;&#34;
+    return self._thread</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="aries_staticagent.static_connection.Session.returning"><code class="name flex">
+<span>def <span class="ident">returning</span></span>(<span>self) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Session set to return route?</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def returning(self) -&gt; bool:
+    &#34;&#34;&#34;Session set to return route?&#34;&#34;&#34;
+    return bool(self._thread)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Session.send"><code class="name flex">
+<span>async def <span class="ident">send</span></span>(<span>self, message: bytes)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Send a packed message to this session.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def send(self, message: bytes):
+    &#34;&#34;&#34;Send a packed message to this session.&#34;&#34;&#34;
+    if not self.returning():
+        raise RuntimeError(&#39;Session is not set to return route&#39;)
+
+    ret = self._send(message)
+    if asyncio.iscoroutine(ret):
+        return await ret
+
+    return ret</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Session.thread_all"><code class="name flex">
+<span>def <span class="ident">thread_all</span></span>(<span>self) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Session is set to return all messages.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def thread_all(self) -&gt; bool:
+    &#34;&#34;&#34;Session is set to return all messages.&#34;&#34;&#34;
+    return self.thread == self.THREAD_ALL</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.Session.update_thread_from_msg"><code class="name flex">
+<span>def <span class="ident">update_thread_from_msg</span></span>(<span>self, msg: <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Update a thread with info from the ~transport decorator.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def update_thread_from_msg(self, msg: Message):
+    &#34;&#34;&#34;Update a thread with info from the ~transport decorator.&#34;&#34;&#34;
+    if &#39;~transport&#39; not in msg and self._thread is None:
+        return
+
+    transport = msg[&#39;~transport&#39;]
+    if transport[&#39;return_route&#39;] == &#39;all&#39;:
+        self._thread = self.THREAD_ALL
+        return
+
+    if transport[&#39;return_route&#39;] == &#39;thread&#39;:
+        self._thread = transport[&#39;return_route_thread&#39;]
+        return
+
+    if transport[&#39;return_route&#39;] == &#39;none&#39;:
+        self._thread = None
+        return</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="aries_staticagent.static_connection.StaticConnection"><code class="flex name class">
+<span>class <span class="ident">StaticConnection</span></span>
+<span>(</span><span>keys: <a title="aries_staticagent.static_connection.Keys" href="#aries_staticagent.static_connection.Keys">Keys</a>, target: <a title="aries_staticagent.static_connection.Target" href="#aries_staticagent.static_connection.Target">Target</a> = None, *, modules: Sequence[Union[<a title="aries_staticagent.module.Module" href="module.html#aries_staticagent.module.Module">Module</a>, type]] = None, send: Callable[[bytes, str], Awaitable[Union[bytes, NoneType]]] = None, dispatcher: <a title="aries_staticagent.dispatcher.Dispatcher" href="dispatcher.html#aries_staticagent.dispatcher.Dispatcher">Dispatcher</a> = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Create a Static Agent Connection to another agent.</p>
 <p>The following will create a Static Connection with just the receiving end
 in place. This makes it possible to receive a message over this connection
 without yet knowing where messages will be sent.</p>
-<pre><code>&gt;&gt;&gt; my_keys = crypto.create_keypair()
-&gt;&gt;&gt; connection = StaticConnection(my_keys)
+<pre><code class="python">&gt;&gt;&gt; my_keys = crypto.create_keypair()
+&gt;&gt;&gt; connection = StaticConnection.receiver(my_keys)
 </code></pre>
 <p>To create a Static Agent Connection with both ends configured:</p>
-<pre><code>&gt;&gt;&gt; their_pretend_verkey = crypto.create_keypair()[0]
-&gt;&gt;&gt; connection = StaticConnection(my_keys, their_vk=their_pretend_verkey)
-&gt;&gt;&gt; connection.recipients == [their_pretend_verkey]
-True
+<pre><code class="python">&gt;&gt;&gt; their_pretend_verkey = crypto.create_keypair()[0]
+&gt;&gt;&gt; connection = StaticConnection.from_parts(
+...     my_keys, their_vk=their_pretend_verkey
+... )
 </code></pre>
 <p>Or, when there are multiple recipients:</p>
-<pre><code>&gt;&gt;&gt; pretend_recips = [ crypto.create_keypair()[0] for i in range(5) ]
-&gt;&gt;&gt; connection = StaticConnection(my_keys, recipients=pretend_recips)
-&gt;&gt;&gt; connection.recipients == pretend_recips
-True
+<pre><code class="python">&gt;&gt;&gt; pretend_recips = [ crypto.create_keypair()[0] for i in range(5) ]
+&gt;&gt;&gt; connection = StaticConnection.from_parts(
+...     my_keys, recipients=pretend_recips
+... )
 </code></pre>
 <p>To specify mediators responsible for forwarding messages to the recipient:</p>
-<pre><code>&gt;&gt;&gt; pretend_mediators = [ crypto.create_keypair()[0] for i in range(5) ]
-&gt;&gt;&gt; connection = StaticConnection(
+<pre><code class="python">&gt;&gt;&gt; pretend_mediators = [ crypto.create_keypair()[0] for i in range(5) ]
+&gt;&gt;&gt; connection = StaticConnection.from_parts(
 ...     my_keys, their_vk=their_pretend_verkey,
 ...     routing_keys=pretend_mediators
 ... )
-&gt;&gt;&gt; connection.routing_keys == pretend_mediators
-True
 </code></pre>
-<p>By default, <a title="aries_staticagent.static_connection.StaticConnection" href="#aries_staticagent.static_connection.StaticConnection"><code>StaticConnection</code></a> will POST messages to the endpoint given
+<p>By default, <code><a title="aries_staticagent.static_connection.StaticConnection" href="#aries_staticagent.static_connection.StaticConnection">StaticConnection</a></code> will POST messages to the endpoint given
 over HTTP. You can, however, specify an alternative <code>Send</code> method for
-<a title="aries_staticagent.static_connection.StaticConnection" href="#aries_staticagent.static_connection.StaticConnection"><code>StaticConnection</code></a> as in the example below:</p>
-<pre><code>&gt;&gt;&gt; async def my_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
+<code><a title="aries_staticagent.static_connection.StaticConnection" href="#aries_staticagent.static_connection.StaticConnection">StaticConnection</a></code> as in the example below:</p>
+<pre><code class="python">&gt;&gt;&gt; async def my_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
 ...     print('pretending to send message to', endpoint)
 ...     response = None
 ...     return response
-&gt;&gt;&gt; connection = StaticConnection(
+&gt;&gt;&gt; connection = StaticConnection.from_parts(
 ...     my_keys, their_vk=their_pretend_verkey,
 ...     endpoint='example.com', send=my_send
 ... )
@@ -557,38 +1120,28 @@ over HTTP. You can, however, specify an alternative <code>Send</code> method for
 pretending to send message to example.com
 </code></pre>
 <h2 id="arguments">Arguments</h2>
-<dl>
-<dt><strong><code>keys</code></strong> :&ensp;<code>tuple</code> of <code>bytes</code> or <code>str</code></dt>
-<dd>A tuple of our public and private key.</dd>
-</dl>
-<h2 id="namedarguments">NamedArguments</h2>
-<dl>
-<dt><strong><code>their_vk</code></strong> :&ensp;<code>bytes</code> or <code>str</code></dt>
-<dd>Specify "their" verification key for this
+<p>keys (tuple of bytes or str): A tuple of our public and private key.</p>
+<h2 id="namedarguments">Namedarguments</h2>
+<p>their_vk (bytes or str): Specify "their" verification key for this
 connection. Specifies only one recipient. Mutually exclusive with
-recipients.</dd>
-<dt><strong><code>recipients</code></strong> :&ensp;[<code>bytes</code> or <code>str</code>]</dt>
-<dd>Specify one or more recipients for this
-connection. Mutually exclusive with their_vk.</dd>
-<dt><strong><code>routing_keys</code></strong> :&ensp;[<code>bytes</code> or <code>str</code>]</dt>
-<dd>Specify one or more mediators for this
-connection.</dd>
-<dt><strong><code>send</code></strong> :&ensp;<code>Send</code></dt>
-<dd>Specify the send method for this connection. See notes
+recipients.</p>
+<p>recipients ([bytes or str]): Specify one or more recipients for this
+connection. Mutually exclusive with their_vk.</p>
+<p>routing_keys ([bytes or str]): Specify one or more mediators for this
+connection.</p>
+<p>send (Send): Specify the send method for this connection. See notes
 above for function signature.
 Defaults to
-<a title="aries_staticagent.utils.http_send" href="utils.html#aries_staticagent.utils.http_send"><code>http_send()</code></a>.</dd>
-<dt><strong><code>dispatcher</code></strong> :&ensp;<a title="aries_staticagent.dispatcher.Dispatcher" href="dispatcher.html#aries_staticagent.dispatcher.Dispatcher"><code>Dispatcher</code></a></dt>
-<dd>Specify a
+<code><a title="aries_staticagent.utils.http_send" href="utils.html#aries_staticagent.utils.http_send">http_send()</a></code>.</p>
+<p>dispatcher (aries_staticagent.dispatcher.Dispatcher): Specify a
 dispatcher for this connection.
 Defaults to
-<a title="aries_staticagent.dispatcher.Dispatcher" href="dispatcher.html#aries_staticagent.dispatcher.Dispatcher"><code>Dispatcher</code></a>.</dd>
-</dl></section>
+<code><a title="aries_staticagent.dispatcher.Dispatcher" href="dispatcher.html#aries_staticagent.dispatcher.Dispatcher">Dispatcher</a></code>.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class StaticConnection:
+<pre><code class="python">class StaticConnection(Keys.Mixin):
     &#34;&#34;&#34;Create a Static Agent Connection to another agent.
 
     The following will create a Static Connection with just the receiving end
@@ -596,28 +1149,26 @@ Defaults to
     without yet knowing where messages will be sent.
 
     &gt;&gt;&gt; my_keys = crypto.create_keypair()
-    &gt;&gt;&gt; connection = StaticConnection(my_keys)
+    &gt;&gt;&gt; connection = StaticConnection.receiver(my_keys)
 
     To create a Static Agent Connection with both ends configured:
     &gt;&gt;&gt; their_pretend_verkey = crypto.create_keypair()[0]
-    &gt;&gt;&gt; connection = StaticConnection(my_keys, their_vk=their_pretend_verkey)
-    &gt;&gt;&gt; connection.recipients == [their_pretend_verkey]
-    True
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
+    ...     my_keys, their_vk=their_pretend_verkey
+    ... )
 
     Or, when there are multiple recipients:
     &gt;&gt;&gt; pretend_recips = [ crypto.create_keypair()[0] for i in range(5) ]
-    &gt;&gt;&gt; connection = StaticConnection(my_keys, recipients=pretend_recips)
-    &gt;&gt;&gt; connection.recipients == pretend_recips
-    True
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
+    ...     my_keys, recipients=pretend_recips
+    ... )
 
     To specify mediators responsible for forwarding messages to the recipient:
     &gt;&gt;&gt; pretend_mediators = [ crypto.create_keypair()[0] for i in range(5) ]
-    &gt;&gt;&gt; connection = StaticConnection(
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
     ...     my_keys, their_vk=their_pretend_verkey,
     ...     routing_keys=pretend_mediators
     ... )
-    &gt;&gt;&gt; connection.routing_keys == pretend_mediators
-    True
 
     By default, `StaticConnection` will POST messages to the endpoint given
     over HTTP. You can, however, specify an alternative `Send` method for
@@ -626,7 +1177,7 @@ Defaults to
     ...     print(&#39;pretending to send message to&#39;, endpoint)
     ...     response = None
     ...     return response
-    &gt;&gt;&gt; connection = StaticConnection(
+    &gt;&gt;&gt; connection = StaticConnection.from_parts(
     ...     my_keys, their_vk=their_pretend_verkey,
     ...     endpoint=&#39;example.com&#39;, send=my_send
     ... )
@@ -659,84 +1210,106 @@ Defaults to
             `aries_staticagent.dispatcher.Dispatcher`.
     &#34;&#34;&#34;
 
-    Keys = namedtuple(&#39;KeyPair&#39;, &#39;verkey, sigkey&#39;)
-
     def __init__(
             self,
-            keys: Tuple[Union[bytes, str], Union[bytes, str]],
+            keys: Keys,
+            target: Target = None,
             *,
-            endpoint: str = None,
-            their_vk: Union[bytes, str] = None,
-            recipients: Sequence[Union[bytes, str]] = None,
-            routing_keys: Sequence[Union[bytes, str]] = None,
+            modules: Sequence[Union[Module, type]] = None,
             send: Send = None,
-            dispatcher: Dispatcher = None):
+            dispatcher: Dispatcher = None
+    ):
 
-        if their_vk and recipients:
-            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+        Keys.Mixin.__init__(self, keys)
+        self.target = target
 
-        self.keys = StaticConnection.Keys(*map(ensure_key_bytes, keys))
-        self.endpoint: Optional[str] = endpoint
-        self.recipients: Optional[List[bytes]] = None
-        self.routing_keys: Optional[List[bytes]] = None
+        if modules:
+            for mod in modules:
+                if isinstance(mod, type):  # attempt to instantiate module
+                    mod = mod()
+                self.route_module(mod)
 
-        if their_vk:
-            self.recipients = [ensure_key_bytes(their_vk)]
-
-        if recipients:
-            self.recipients = list(map(ensure_key_bytes, recipients))
-
-        if routing_keys:
-            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
-
-        self._dispatcher = dispatcher if dispatcher else Dispatcher()
-        self._next: ConditionFutureMap = {}
-        self._reply: Optional[Reply] = None
         self._send: Send = send if send else http_send
+        self._dispatcher = dispatcher if dispatcher else Dispatcher()
 
-    def update(
-            self,
+        self._next: ConditionFutureMap = {}
+        self._sessions: Set[Session] = set()
+
+    @classmethod
+    def from_parts(
+            cls,
+            keys: Union[Keys, Tuple[Keys.Key, Keys.Key]],
             *,
             endpoint: str = None,
             their_vk: Union[bytes, str] = None,
             recipients: Sequence[Union[bytes, str]] = None,
             routing_keys: Sequence[Union[bytes, str]] = None,
-            **_kwargs):
-        &#34;&#34;&#34;Update their information.&#34;&#34;&#34;
-        if their_vk and recipients:
-            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+            **kwargs
+    ):
+        &#34;&#34;&#34;Construct a static connection from its parts.
 
-        if endpoint:
-            self.endpoint = endpoint
+        Arguments:
 
-        if their_vk:
-            self.recipients = [ensure_key_bytes(their_vk)]
+            keys (tuple of bytes or str): A tuple of our public and private
+            key.
 
-        if recipients:
-            self.recipients = list(map(ensure_key_bytes, recipients))
+        NamedArguments:
 
-        if routing_keys:
-            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
+            their_vk (bytes or str): Specify &#34;their&#34; verification key for this
+                connection. Specifies only one recipient. Mutually exclusive
+                with recipients.
 
-    @property
-    def verkey(self):
-        &#34;&#34;&#34;My verification key for this connection.&#34;&#34;&#34;
-        return self.keys.verkey
+            recipients ([bytes or str]): Specify one or more recipients for
+                this connection. Mutually exclusive with their_vk.
 
-    @property
-    def verkey_b58(self):
-        &#34;&#34;&#34;Get Base58 encoded my_vk.&#34;&#34;&#34;
-        return crypto.bytes_to_b58(self.keys.verkey)
+            routing_keys ([bytes or str]): Specify one or more mediators for
+                this connection.
 
-    @property
-    def sigkey(self):
-        &#34;&#34;&#34;My signing key for this connection.&#34;&#34;&#34;
-        return self.keys.sigkey
+            send (Send): Specify the send method for this connection. See notes
+                above for function signature.  Defaults to
+                `aries_staticagent.utils.http_send`.
 
-    @property
-    def did(self):
-        &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
-        return crypto.bytes_to_b58(self.keys.verkey[:16])
+            dispatcher (aries_staticagent.dispatcher.Dispatcher): Specify a
+                dispatcher for this connection.  Defaults to
+                `aries_staticagent.dispatcher.Dispatcher`.
+        &#34;&#34;&#34;
+        if not isinstance(keys, Keys):
+            keys = Keys(*keys)
+        target = None
+        if endpoint or their_vk or recipients or routing_keys:
+            target = Target(
+                endpoint=endpoint,
+                their_vk=their_vk,
+                recipients=recipients,
+                routing_keys=routing_keys
+            )
+        return cls(keys, target, **kwargs)
+
+    @classmethod
+    def receiver(
+            cls,
+            keys: Union[Keys, Tuple[Keys.Key, Keys.Key]],
+            **kwargs
+    ):
+        &#34;&#34;&#34;Create a static connection to be used only for receiving messages.
+
+        Arguments:
+
+            keys (Keys or Tuple of keys): Our public and private keys.
+        &#34;&#34;&#34;
+        if not isinstance(keys, Keys):
+            keys = Keys(*keys)
+        return cls(keys, **kwargs)
+
+    @classmethod
+    def random(cls, target: Target = None, **kwargs):
+        &#34;&#34;&#34;Generate connection with random keys.&#34;&#34;&#34;
+        return cls(Keys(*crypto.create_keypair()), target, **kwargs)
+
+    @classmethod
+    def from_seed(cls, seed: str, target: Target = None, **kwargs):
+        &#34;&#34;&#34;Generate connection from seed.&#34;&#34;&#34;
+        return cls(Keys(*crypto.create_keypair(seed=seed)), target, **kwargs)
 
     def route(self, msg_type: str) -&gt; Callable:
         &#34;&#34;&#34;Register route decorator.&#34;&#34;&#34;
@@ -851,62 +1424,72 @@ Defaults to
         if plaintext:
             return json.dumps(msg).encode(&#39;ascii&#39;)
 
-        if not self.recipients:
+        if not self.target or not self.target.recipients:
             raise RuntimeError(&#39;No recipients for whom to pack this message&#39;)
 
         if anoncrypt:
             packed_message = crypto.pack_message(
                 msg.serialize(),
-                self.recipients,
+                self.target.recipients,
             )
         else:
             packed_message = crypto.pack_message(
                 msg.serialize(),
-                self.recipients,
+                self.target.recipients,
                 self.verkey,
                 self.sigkey,
             )
 
-        if self.routing_keys:
-            to = self.recipients[0]
-            for routing_key in self.routing_keys:
+        if self.target.routing_keys:
+            forward_to = self.target.recipients[0]
+            for routing_key in self.target.routing_keys:
                 packed_message = crypto.pack_message(
-                    forward_msg(to=to, msg=packed_message).serialize(),
+                    forward_msg(to=forward_to, msg=packed_message).serialize(),
                     [routing_key],
                 )
-                to = routing_key
+                forward_to = routing_key
 
         return json.dumps(packed_message).encode(&#39;ascii&#39;)
 
     @contextmanager
-    def reply_handler(
+    def session(self, send: SessionSend):
+        &#34;&#34;&#34;Open a new session for this connection.&#34;&#34;&#34;
+
+        session = Session(send)
+        self._sessions.add(session)
+        yield session
+        self._sessions.remove(session)
+
+    def session_open(self) -&gt; bool:
+        &#34;&#34;&#34;Check whether connection has sessions open.&#34;&#34;&#34;
+        return bool(self._sessions)
+
+    async def send_to_session(
             self,
-            reply: Reply):
-        &#34;&#34;&#34;
-        Set a reply handler to be used in sending messages rather than opening
-        a new connection.
-        &#34;&#34;&#34;
-        self._reply = reply
-        yield
-        self._reply = None
+            message: bytes,
+            thread: str = None
+    ) -&gt; bool:
+        &#34;&#34;&#34;Send a message to all sessions with a matching thread.&#34;&#34;&#34;
+        if not self._sessions:
+            raise RuntimeError(
+                &#39;Cannot send message to session; no open sessions&#39;
+            )
 
-    def can_reply(self) -&gt; bool:
-        &#34;&#34;&#34;Check whether connection can reply.&#34;&#34;&#34;
-        return self._reply is not None
+        sent = False
+        for session in self._sessions:
+            if not session.returning():
+                continue
 
-    async def reply(self, message: bytes):
-        &#34;&#34;&#34;Call reply method.&#34;&#34;&#34;
-        if self._reply is None:
-            raise RuntimeError(&#39;Cannot reply; no reply handler is set&#39;)
-        await self._reply(message)
+            if session.thread == thread or session.thread_all():
+                await session.send(message)
+                sent = True
+        return sent
 
-    async def handle(self, packed_message: bytes):
+    async def handle(self, packed_message: bytes, session: Session = None):
         &#34;&#34;&#34;Unpack and dispatch message to handler.&#34;&#34;&#34;
         msg = self.unpack(packed_message)
-        if (&#39;~transport&#39; not in msg or
-                &#39;return_route&#39; not in msg[&#39;~transport&#39;] or
-                msg[&#39;~transport&#39;][&#39;return_route&#39;] == &#39;none&#39;):
-            self._reply = None
+        if session:
+            session.update_thread_from_msg(msg)
 
         for condition, next_message_future in self._next.items():
             if condition(msg) and not next_message_future.done():
@@ -925,8 +1508,14 @@ Defaults to
         &#34;&#34;&#34;
         Send a message to the agent connected through this StaticConnection.
         &#34;&#34;&#34;
-        # not can_reply indicates this is an outbound message
-        if return_route and not self.can_reply():
+        if not isinstance(msg, Message):
+            if isinstance(msg, dict):
+                msg = Message(msg)
+            else:
+                raise TypeError(&#39;msg must be type Message or dict&#39;)
+
+        # TODO: Don&#39;t specify return route on messages sent to sessions?
+        if return_route:
             if &#39;~transport&#39; not in msg:
                 msg[&#39;~transport&#39;] = {}
             msg[&#39;~transport&#39;][&#39;return_route&#39;] = return_route
@@ -935,11 +1524,11 @@ Defaults to
             msg, anoncrypt=anoncrypt, plaintext=plaintext
         )
 
-        if self.can_reply():
-            await self.reply(packed_message)
-            return
+        if self.session_open():
+            if await self.send_to_session(packed_message, msg.thread[&#39;thid&#39;]):
+                return
 
-        if not self.endpoint:
+        if not self.target or not self.target.endpoint:
             raise MessageDeliveryError(
                 msg=&#39;Cannot send message; no endpoint and no return route.&#39;
             )
@@ -947,7 +1536,7 @@ Defaults to
         try:
             response = await self._send(
                 packed_message,
-                self.endpoint
+                self.target.endpoint
             )
         except Exception as err:
             raise MessageDeliveryError(msg=str(err)) from err
@@ -968,7 +1557,8 @@ Defaults to
             return_route: str = &#34;all&#34;,
             plaintext: bool = False,
             anoncrypt: bool = False,
-            timeout: int = None) -&gt; Message:
+            timeout: int = None
+    ) -&gt; Message:
         &#34;&#34;&#34;Send a message and wait for a reply.&#34;&#34;&#34;
 
         with self.next(type_=type_, condition=condition) as next_message:
@@ -985,7 +1575,8 @@ Defaults to
             *,
             type_: str = None,
             condition: Callable[[Message], bool] = None,
-            timeout: int = None):
+            timeout: int = None
+    ):
         &#34;&#34;&#34;
         Wait for a message.
 
@@ -1009,79 +1600,161 @@ Defaults to
             self.send_and_await_reply_async(*args, **kwargs)
         )</code></pre>
 </details>
-<h3>Class variables</h3>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="aries_staticagent.static_connection.Keys.Mixin" href="#aries_staticagent.static_connection.Keys.Mixin">Keys.Mixin</a></li>
+</ul>
+<h3>Static methods</h3>
 <dl>
-<dt id="aries_staticagent.static_connection.StaticConnection.Keys"><code class="name">var <span class="ident">Keys</span></code></dt>
+<dt id="aries_staticagent.static_connection.StaticConnection.from_parts"><code class="name flex">
+<span>def <span class="ident">from_parts</span></span>(<span>keys: Union[<a title="aries_staticagent.static_connection.Keys" href="#aries_staticagent.static_connection.Keys">Keys</a>, Tuple[Union[bytes, str], Union[bytes, str]]], *, endpoint: str = None, their_vk: Union[bytes, str] = None, recipients: Sequence[Union[bytes, str]] = None, routing_keys: Sequence[Union[bytes, str]] = None, **kwargs)</span>
+</code></dt>
 <dd>
-<section class="desc"><p>KeyPair(verkey, sigkey)</p></section>
-</dd>
-</dl>
-<h3>Instance variables</h3>
-<dl>
-<dt id="aries_staticagent.static_connection.StaticConnection.did"><code class="name">var <span class="ident">did</span></code></dt>
-<dd>
-<section class="desc"><p>Get verkey based DID for this connection.</p></section>
+<div class="desc"><p>Construct a static connection from its parts.</p>
+<h2 id="arguments">Arguments</h2>
+<p>keys (tuple of bytes or str): A tuple of our public and private
+key.</p>
+<h2 id="namedarguments">Namedarguments</h2>
+<p>their_vk (bytes or str): Specify "their" verification key for this
+connection. Specifies only one recipient. Mutually exclusive
+with recipients.</p>
+<p>recipients ([bytes or str]): Specify one or more recipients for
+this connection. Mutually exclusive with their_vk.</p>
+<p>routing_keys ([bytes or str]): Specify one or more mediators for
+this connection.</p>
+<p>send (Send): Specify the send method for this connection. See notes
+above for function signature.
+Defaults to
+<code><a title="aries_staticagent.utils.http_send" href="utils.html#aries_staticagent.utils.http_send">http_send()</a></code>.</p>
+<p>dispatcher (aries_staticagent.dispatcher.Dispatcher): Specify a
+dispatcher for this connection.
+Defaults to
+<code><a title="aries_staticagent.dispatcher.Dispatcher" href="dispatcher.html#aries_staticagent.dispatcher.Dispatcher">Dispatcher</a></code>.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">@property
-def did(self):
-    &#34;&#34;&#34;Get verkey based DID for this connection.&#34;&#34;&#34;
-    return crypto.bytes_to_b58(self.keys.verkey[:16])</code></pre>
+<pre><code class="python">@classmethod
+def from_parts(
+        cls,
+        keys: Union[Keys, Tuple[Keys.Key, Keys.Key]],
+        *,
+        endpoint: str = None,
+        their_vk: Union[bytes, str] = None,
+        recipients: Sequence[Union[bytes, str]] = None,
+        routing_keys: Sequence[Union[bytes, str]] = None,
+        **kwargs
+):
+    &#34;&#34;&#34;Construct a static connection from its parts.
+
+    Arguments:
+
+        keys (tuple of bytes or str): A tuple of our public and private
+        key.
+
+    NamedArguments:
+
+        their_vk (bytes or str): Specify &#34;their&#34; verification key for this
+            connection. Specifies only one recipient. Mutually exclusive
+            with recipients.
+
+        recipients ([bytes or str]): Specify one or more recipients for
+            this connection. Mutually exclusive with their_vk.
+
+        routing_keys ([bytes or str]): Specify one or more mediators for
+            this connection.
+
+        send (Send): Specify the send method for this connection. See notes
+            above for function signature.  Defaults to
+            `aries_staticagent.utils.http_send`.
+
+        dispatcher (aries_staticagent.dispatcher.Dispatcher): Specify a
+            dispatcher for this connection.  Defaults to
+            `aries_staticagent.dispatcher.Dispatcher`.
+    &#34;&#34;&#34;
+    if not isinstance(keys, Keys):
+        keys = Keys(*keys)
+    target = None
+    if endpoint or their_vk or recipients or routing_keys:
+        target = Target(
+            endpoint=endpoint,
+            their_vk=their_vk,
+            recipients=recipients,
+            routing_keys=routing_keys
+        )
+    return cls(keys, target, **kwargs)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.sigkey"><code class="name">var <span class="ident">sigkey</span></code></dt>
+<dt id="aries_staticagent.static_connection.StaticConnection.from_seed"><code class="name flex">
+<span>def <span class="ident">from_seed</span></span>(<span>seed: str, target: <a title="aries_staticagent.static_connection.Target" href="#aries_staticagent.static_connection.Target">Target</a> = None, **kwargs)</span>
+</code></dt>
 <dd>
-<section class="desc"><p>My signing key for this connection.</p></section>
+<div class="desc"><p>Generate connection from seed.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">@property
-def sigkey(self):
-    &#34;&#34;&#34;My signing key for this connection.&#34;&#34;&#34;
-    return self.keys.sigkey</code></pre>
+<pre><code class="python">@classmethod
+def from_seed(cls, seed: str, target: Target = None, **kwargs):
+    &#34;&#34;&#34;Generate connection from seed.&#34;&#34;&#34;
+    return cls(Keys(*crypto.create_keypair(seed=seed)), target, **kwargs)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.verkey"><code class="name">var <span class="ident">verkey</span></code></dt>
+<dt id="aries_staticagent.static_connection.StaticConnection.random"><code class="name flex">
+<span>def <span class="ident">random</span></span>(<span>target: <a title="aries_staticagent.static_connection.Target" href="#aries_staticagent.static_connection.Target">Target</a> = None, **kwargs)</span>
+</code></dt>
 <dd>
-<section class="desc"><p>My verification key for this connection.</p></section>
+<div class="desc"><p>Generate connection with random keys.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">@property
-def verkey(self):
-    &#34;&#34;&#34;My verification key for this connection.&#34;&#34;&#34;
-    return self.keys.verkey</code></pre>
+<pre><code class="python">@classmethod
+def random(cls, target: Target = None, **kwargs):
+    &#34;&#34;&#34;Generate connection with random keys.&#34;&#34;&#34;
+    return cls(Keys(*crypto.create_keypair()), target, **kwargs)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.verkey_b58"><code class="name">var <span class="ident">verkey_b58</span></code></dt>
+<dt id="aries_staticagent.static_connection.StaticConnection.receiver"><code class="name flex">
+<span>def <span class="ident">receiver</span></span>(<span>keys: Union[<a title="aries_staticagent.static_connection.Keys" href="#aries_staticagent.static_connection.Keys">Keys</a>, Tuple[Union[bytes, str], Union[bytes, str]]], **kwargs)</span>
+</code></dt>
 <dd>
-<section class="desc"><p>Get Base58 encoded my_vk.</p></section>
+<div class="desc"><p>Create a static connection to be used only for receiving messages.</p>
+<h2 id="arguments">Arguments</h2>
+<p>keys (Keys or Tuple of keys): Our public and private keys.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">@property
-def verkey_b58(self):
-    &#34;&#34;&#34;Get Base58 encoded my_vk.&#34;&#34;&#34;
-    return crypto.bytes_to_b58(self.keys.verkey)</code></pre>
+<pre><code class="python">@classmethod
+def receiver(
+        cls,
+        keys: Union[Keys, Tuple[Keys.Key, Keys.Key]],
+        **kwargs
+):
+    &#34;&#34;&#34;Create a static connection to be used only for receiving messages.
+
+    Arguments:
+
+        keys (Keys or Tuple of keys): Our public and private keys.
+    &#34;&#34;&#34;
+    if not isinstance(keys, Keys):
+        keys = Keys(*keys)
+    return cls(keys, **kwargs)</code></pre>
 </details>
 </dd>
 </dl>
 <h3>Methods</h3>
 <dl>
 <dt id="aries_staticagent.static_connection.StaticConnection.await_message"><code class="name flex">
-<span>async def <span class="ident">await_message</span></span>(<span>self, *, type_=None, condition=None, timeout=None)</span>
+<span>async def <span class="ident">await_message</span></span>(<span>self, *, type_: str = None, condition: Callable[[<a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>], bool] = None, timeout: int = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Wait for a message.</p>
+<div class="desc"><p>Wait for a message.</p>
 <p>Note that it's possible for a message to arrive just before or during
 the setup of this function. If it's likely that a message will arrive
 as a result of an action taken prior to calling await_message, use the
-<code>next</code> context manager instead.</p></section>
+<code>next</code> context manager instead.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1091,7 +1764,8 @@ as a result of an action taken prior to calling await_message, use the
         *,
         type_: str = None,
         condition: Callable[[Message], bool] = None,
-        timeout: int = None):
+        timeout: int = None
+):
     &#34;&#34;&#34;
     Wait for a message.
 
@@ -1104,25 +1778,11 @@ as a result of an action taken prior to calling await_message, use the
         return await asyncio.wait_for(next_message, timeout)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.can_reply"><code class="name flex">
-<span>def <span class="ident">can_reply</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Check whether connection can reply.</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def can_reply(self) -&gt; bool:
-    &#34;&#34;&#34;Check whether connection can reply.&#34;&#34;&#34;
-    return self._reply is not None</code></pre>
-</details>
-</dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.clear_routes"><code class="name flex">
 <span>def <span class="ident">clear_routes</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Clear registered routes.</p></section>
+<div class="desc"><p>Clear registered routes.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1136,7 +1796,7 @@ as a result of an action taken prior to calling await_message, use the
 <span>async def <span class="ident">dispatch</span></span>(<span>self, message)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Dispatch message to handler.</p></section>
+<div class="desc"><p>Dispatch message to handler.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1149,21 +1809,19 @@ as a result of an action taken prior to calling await_message, use the
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.handle"><code class="name flex">
-<span>async def <span class="ident">handle</span></span>(<span>self, packed_message)</span>
+<span>async def <span class="ident">handle</span></span>(<span>self, packed_message: bytes, session: <a title="aries_staticagent.static_connection.Session" href="#aries_staticagent.static_connection.Session">Session</a> = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Unpack and dispatch message to handler.</p></section>
+<div class="desc"><p>Unpack and dispatch message to handler.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def handle(self, packed_message: bytes):
+<pre><code class="python">async def handle(self, packed_message: bytes, session: Session = None):
     &#34;&#34;&#34;Unpack and dispatch message to handler.&#34;&#34;&#34;
     msg = self.unpack(packed_message)
-    if (&#39;~transport&#39; not in msg or
-            &#39;return_route&#39; not in msg[&#39;~transport&#39;] or
-            msg[&#39;~transport&#39;][&#39;return_route&#39;] == &#39;none&#39;):
-        self._reply = None
+    if session:
+        session.update_thread_from_msg(msg)
 
     for condition, next_message_future in self._next.items():
         if condition(msg) and not next_message_future.done():
@@ -1174,14 +1832,14 @@ as a result of an action taken prior to calling await_message, use the
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.next"><code class="name flex">
-<span>def <span class="ident">next</span></span>(<span>self, type_=None, condition=None)</span>
+<span>def <span class="ident">next</span></span>(<span>self, type_: str = None, condition: Callable[[<a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>], bool] = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Context manager to claim the next message matching condtion, allowing
+<div class="desc"><p>Context manager to claim the next message matching condtion, allowing
 temporary bypass of regular dispatch.</p>
 <p>This will consume only the next message matching condition. If you need
 to consume more than one or two, consider using a standard message
-handler or overriding the default dispatching mechanism.</p></section>
+handler or overriding the default dispatching mechanism.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1227,10 +1885,10 @@ def next(
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.pack"><code class="name flex">
-<span>def <span class="ident">pack</span></span>(<span>self, msg, anoncrypt=False, plaintext=False)</span>
+<span>def <span class="ident">pack</span></span>(<span>self, msg: Union[dict, <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>], anoncrypt=False, plaintext=False) ‑> bytes</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Pack a message for sending over the wire.</p></section>
+<div class="desc"><p>Pack a message for sending over the wire.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1255,78 +1913,39 @@ def next(
     if plaintext:
         return json.dumps(msg).encode(&#39;ascii&#39;)
 
-    if not self.recipients:
+    if not self.target or not self.target.recipients:
         raise RuntimeError(&#39;No recipients for whom to pack this message&#39;)
 
     if anoncrypt:
         packed_message = crypto.pack_message(
             msg.serialize(),
-            self.recipients,
+            self.target.recipients,
         )
     else:
         packed_message = crypto.pack_message(
             msg.serialize(),
-            self.recipients,
+            self.target.recipients,
             self.verkey,
             self.sigkey,
         )
 
-    if self.routing_keys:
-        to = self.recipients[0]
-        for routing_key in self.routing_keys:
+    if self.target.routing_keys:
+        forward_to = self.target.recipients[0]
+        for routing_key in self.target.routing_keys:
             packed_message = crypto.pack_message(
-                forward_msg(to=to, msg=packed_message).serialize(),
+                forward_msg(to=forward_to, msg=packed_message).serialize(),
                 [routing_key],
             )
-            to = routing_key
+            forward_to = routing_key
 
     return json.dumps(packed_message).encode(&#39;ascii&#39;)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.reply"><code class="name flex">
-<span>async def <span class="ident">reply</span></span>(<span>self, message)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Call reply method.</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">async def reply(self, message: bytes):
-    &#34;&#34;&#34;Call reply method.&#34;&#34;&#34;
-    if self._reply is None:
-        raise RuntimeError(&#39;Cannot reply; no reply handler is set&#39;)
-    await self._reply(message)</code></pre>
-</details>
-</dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.reply_handler"><code class="name flex">
-<span>def <span class="ident">reply_handler</span></span>(<span>self, reply)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Set a reply handler to be used in sending messages rather than opening
-a new connection.</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@contextmanager
-def reply_handler(
-        self,
-        reply: Reply):
-    &#34;&#34;&#34;
-    Set a reply handler to be used in sending messages rather than opening
-    a new connection.
-    &#34;&#34;&#34;
-    self._reply = reply
-    yield
-    self._reply = None</code></pre>
-</details>
-</dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.route"><code class="name flex">
-<span>def <span class="ident">route</span></span>(<span>self, msg_type)</span>
+<span>def <span class="ident">route</span></span>(<span>self, msg_type: str) ‑> Callable</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Register route decorator.</p></section>
+<div class="desc"><p>Register route decorator.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1343,10 +1962,10 @@ def reply_handler(
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.route_module"><code class="name flex">
-<span>def <span class="ident">route_module</span></span>(<span>self, module)</span>
+<span>def <span class="ident">route_module</span></span>(<span>self, module: <a title="aries_staticagent.module.Module" href="module.html#aries_staticagent.module.Module">Module</a>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Register a module for routing.</p></section>
+<div class="desc"><p>Register a module for routing.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1364,7 +1983,7 @@ def reply_handler(
 <span>def <span class="ident">send</span></span>(<span>self, *args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Blocking wrapper around send_async.</p></section>
+<div class="desc"><p>Blocking wrapper around send_async.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1376,10 +1995,10 @@ def reply_handler(
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.send_and_await_reply"><code class="name flex">
-<span>def <span class="ident">send_and_await_reply</span></span>(<span>self, *args, **kwargs)</span>
+<span>def <span class="ident">send_and_await_reply</span></span>(<span>self, *args, **kwargs) ‑> <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a></span>
 </code></dt>
 <dd>
-<section class="desc"><p>Blocking wrapper around send_and_await_reply_async.</p></section>
+<div class="desc"><p>Blocking wrapper around send_and_await_reply_async.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1393,10 +2012,10 @@ def reply_handler(
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.send_and_await_reply_async"><code class="name flex">
-<span>async def <span class="ident">send_and_await_reply_async</span></span>(<span>self, msg, *, type_=None, condition=None, return_route='all', plaintext=False, anoncrypt=False, timeout=None)</span>
+<span>async def <span class="ident">send_and_await_reply_async</span></span>(<span>self, msg: Union[dict, <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>], *, type_: str = None, condition: Callable[[<a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>], bool] = None, return_route: str = 'all', plaintext: bool = False, anoncrypt: bool = False, timeout: int = None) ‑> <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a></span>
 </code></dt>
 <dd>
-<section class="desc"><p>Send a message and wait for a reply.</p></section>
+<div class="desc"><p>Send a message and wait for a reply.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1410,7 +2029,8 @@ def reply_handler(
         return_route: str = &#34;all&#34;,
         plaintext: bool = False,
         anoncrypt: bool = False,
-        timeout: int = None) -&gt; Message:
+        timeout: int = None
+) -&gt; Message:
     &#34;&#34;&#34;Send a message and wait for a reply.&#34;&#34;&#34;
 
     with self.next(type_=type_, condition=condition) as next_message:
@@ -1424,10 +2044,10 @@ def reply_handler(
 </details>
 </dd>
 <dt id="aries_staticagent.static_connection.StaticConnection.send_async"><code class="name flex">
-<span>async def <span class="ident">send_async</span></span>(<span>self, msg, *, return_route=None, plaintext=False, anoncrypt=False)</span>
+<span>async def <span class="ident">send_async</span></span>(<span>self, msg: Union[dict, <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a>], *, return_route: str = None, plaintext: bool = False, anoncrypt: bool = False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Send a message to the agent connected through this StaticConnection.</p></section>
+<div class="desc"><p>Send a message to the agent connected through this StaticConnection.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1442,8 +2062,14 @@ def reply_handler(
     &#34;&#34;&#34;
     Send a message to the agent connected through this StaticConnection.
     &#34;&#34;&#34;
-    # not can_reply indicates this is an outbound message
-    if return_route and not self.can_reply():
+    if not isinstance(msg, Message):
+        if isinstance(msg, dict):
+            msg = Message(msg)
+        else:
+            raise TypeError(&#39;msg must be type Message or dict&#39;)
+
+    # TODO: Don&#39;t specify return route on messages sent to sessions?
+    if return_route:
         if &#39;~transport&#39; not in msg:
             msg[&#39;~transport&#39;] = {}
         msg[&#39;~transport&#39;][&#39;return_route&#39;] = return_route
@@ -1452,11 +2078,11 @@ def reply_handler(
         msg, anoncrypt=anoncrypt, plaintext=plaintext
     )
 
-    if self.can_reply():
-        await self.reply(packed_message)
-        return
+    if self.session_open():
+        if await self.send_to_session(packed_message, msg.thread[&#39;thid&#39;]):
+            return
 
-    if not self.endpoint:
+    if not self.target or not self.target.endpoint:
         raise MessageDeliveryError(
             msg=&#39;Cannot send message; no endpoint and no return route.&#39;
         )
@@ -1464,7 +2090,7 @@ def reply_handler(
     try:
         response = await self._send(
             packed_message,
-            self.endpoint
+            self.target.endpoint
         )
     except Exception as err:
         raise MessageDeliveryError(msg=str(err)) from err
@@ -1477,11 +2103,75 @@ def reply_handler(
         await self.handle(response)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.unpack"><code class="name flex">
-<span>def <span class="ident">unpack</span></span>(<span>self, packed_message)</span>
+<dt id="aries_staticagent.static_connection.StaticConnection.send_to_session"><code class="name flex">
+<span>async def <span class="ident">send_to_session</span></span>(<span>self, message: bytes, thread: str = None) ‑> bool</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Unpack a message, filling out metadata in the MTC.</p></section>
+<div class="desc"><p>Send a message to all sessions with a matching thread.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def send_to_session(
+        self,
+        message: bytes,
+        thread: str = None
+) -&gt; bool:
+    &#34;&#34;&#34;Send a message to all sessions with a matching thread.&#34;&#34;&#34;
+    if not self._sessions:
+        raise RuntimeError(
+            &#39;Cannot send message to session; no open sessions&#39;
+        )
+
+    sent = False
+    for session in self._sessions:
+        if not session.returning():
+            continue
+
+        if session.thread == thread or session.thread_all():
+            await session.send(message)
+            sent = True
+    return sent</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.StaticConnection.session"><code class="name flex">
+<span>def <span class="ident">session</span></span>(<span>self, send: Callable[[bytes], Awaitable[NoneType]])</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Open a new session for this connection.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@contextmanager
+def session(self, send: SessionSend):
+    &#34;&#34;&#34;Open a new session for this connection.&#34;&#34;&#34;
+
+    session = Session(send)
+    self._sessions.add(session)
+    yield session
+    self._sessions.remove(session)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.StaticConnection.session_open"><code class="name flex">
+<span>def <span class="ident">session_open</span></span>(<span>self) ‑> bool</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Check whether connection has sessions open.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def session_open(self) -&gt; bool:
+    &#34;&#34;&#34;Check whether connection has sessions open.&#34;&#34;&#34;
+    return bool(self._sessions)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.static_connection.StaticConnection.unpack"><code class="name flex">
+<span>def <span class="ident">unpack</span></span>(<span>self, packed_message: Union[bytes, dict]) ‑> <a title="aries_staticagent.message.Message" href="message.html#aries_staticagent.message.Message">Message</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Unpack a message, filling out metadata in the MTC.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1513,11 +2203,76 @@ def reply_handler(
     return msg</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.static_connection.StaticConnection.update"><code class="name flex">
-<span>def <span class="ident">update</span></span>(<span>self, *, endpoint=None, their_vk=None, recipients=None, routing_keys=None, **_kwargs)</span>
+</dl>
+</dd>
+<dt id="aries_staticagent.static_connection.Target"><code class="flex name class">
+<span>class <span class="ident">Target</span></span>
+<span>(</span><span>*, endpoint: str = None, their_vk: Union[bytes, str] = None, recipients: Sequence[Union[bytes, str]] = None, routing_keys: Sequence[Union[bytes, str]] = None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Update their information.</p></section>
+<div class="desc"><p>Container for information about our message destination.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Target:
+    &#34;&#34;&#34;Container for information about our message destination.&#34;&#34;&#34;
+    def __init__(
+            self,
+            *,
+            endpoint: str = None,
+            their_vk: Union[bytes, str] = None,
+            recipients: Sequence[Union[bytes, str]] = None,
+            routing_keys: Sequence[Union[bytes, str]] = None
+    ):
+        if their_vk and recipients:
+            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+
+        self.endpoint: Optional[str] = endpoint
+        self.recipients: Optional[List[bytes]] = None
+        self.routing_keys: Optional[List[bytes]] = None
+
+        if their_vk:
+            self.recipients = [ensure_key_bytes(their_vk)]
+
+        if recipients:
+            self.recipients = list(map(ensure_key_bytes, recipients))
+
+        if routing_keys:
+            self.routing_keys = list(map(ensure_key_bytes, routing_keys))
+
+    def update(
+            self,
+            *,
+            endpoint: str = None,
+            their_vk: Union[bytes, str] = None,
+            recipients: Sequence[Union[bytes, str]] = None,
+            routing_keys: Sequence[Union[bytes, str]] = None,
+            **_kwargs
+    ):
+        &#34;&#34;&#34;Update their information.&#34;&#34;&#34;
+        if their_vk and recipients:
+            raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
+
+        if endpoint:
+            self.endpoint = endpoint
+
+        if their_vk:
+            self.recipients = [ensure_key_bytes(their_vk)]
+
+        if recipients:
+            self.recipients = list(map(ensure_key_bytes, recipients))
+
+        if routing_keys:
+            self.routing_keys = list(map(ensure_key_bytes, routing_keys))</code></pre>
+</details>
+<h3>Methods</h3>
+<dl>
+<dt id="aries_staticagent.static_connection.Target.update"><code class="name flex">
+<span>def <span class="ident">update</span></span>(<span>self, *, endpoint: str = None, their_vk: Union[bytes, str] = None, recipients: Sequence[Union[bytes, str]] = None, routing_keys: Sequence[Union[bytes, str]] = None, **_kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Update their information.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1529,7 +2284,8 @@ def reply_handler(
         their_vk: Union[bytes, str] = None,
         recipients: Sequence[Union[bytes, str]] = None,
         routing_keys: Sequence[Union[bytes, str]] = None,
-        **_kwargs):
+        **_kwargs
+):
     &#34;&#34;&#34;Update their information.&#34;&#34;&#34;
     if their_vk and recipients:
         raise ValueError(&#39;their_vk and recipients are mutually exclusive.&#39;)
@@ -1566,33 +2322,60 @@ def reply_handler(
 <li><h3><a href="#header-classes">Classes</a></h3>
 <ul>
 <li>
+<h4><code><a title="aries_staticagent.static_connection.Keys" href="#aries_staticagent.static_connection.Keys">Keys</a></code></h4>
+<ul class="two-column">
+<li><code><a title="aries_staticagent.static_connection.Keys.Key" href="#aries_staticagent.static_connection.Keys.Key">Key</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Keys.Mixin" href="#aries_staticagent.static_connection.Keys.Mixin">Mixin</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Keys.did" href="#aries_staticagent.static_connection.Keys.did">did</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Keys.sigkey" href="#aries_staticagent.static_connection.Keys.sigkey">sigkey</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Keys.verkey" href="#aries_staticagent.static_connection.Keys.verkey">verkey</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Keys.verkey_b58" href="#aries_staticagent.static_connection.Keys.verkey_b58">verkey_b58</a></code></li>
+</ul>
+</li>
+<li>
 <h4><code><a title="aries_staticagent.static_connection.MessageDeliveryError" href="#aries_staticagent.static_connection.MessageDeliveryError">MessageDeliveryError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="aries_staticagent.static_connection.Session" href="#aries_staticagent.static_connection.Session">Session</a></code></h4>
+<ul class="">
+<li><code><a title="aries_staticagent.static_connection.Session.THREAD_ALL" href="#aries_staticagent.static_connection.Session.THREAD_ALL">THREAD_ALL</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Session.returning" href="#aries_staticagent.static_connection.Session.returning">returning</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Session.send" href="#aries_staticagent.static_connection.Session.send">send</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Session.session_id" href="#aries_staticagent.static_connection.Session.session_id">session_id</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Session.thread" href="#aries_staticagent.static_connection.Session.thread">thread</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Session.thread_all" href="#aries_staticagent.static_connection.Session.thread_all">thread_all</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.Session.update_thread_from_msg" href="#aries_staticagent.static_connection.Session.update_thread_from_msg">update_thread_from_msg</a></code></li>
+</ul>
 </li>
 <li>
 <h4><code><a title="aries_staticagent.static_connection.StaticConnection" href="#aries_staticagent.static_connection.StaticConnection">StaticConnection</a></code></h4>
 <ul class="">
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.Keys" href="#aries_staticagent.static_connection.StaticConnection.Keys">Keys</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.await_message" href="#aries_staticagent.static_connection.StaticConnection.await_message">await_message</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.can_reply" href="#aries_staticagent.static_connection.StaticConnection.can_reply">can_reply</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.clear_routes" href="#aries_staticagent.static_connection.StaticConnection.clear_routes">clear_routes</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.did" href="#aries_staticagent.static_connection.StaticConnection.did">did</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.dispatch" href="#aries_staticagent.static_connection.StaticConnection.dispatch">dispatch</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.from_parts" href="#aries_staticagent.static_connection.StaticConnection.from_parts">from_parts</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.from_seed" href="#aries_staticagent.static_connection.StaticConnection.from_seed">from_seed</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.handle" href="#aries_staticagent.static_connection.StaticConnection.handle">handle</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.next" href="#aries_staticagent.static_connection.StaticConnection.next">next</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.pack" href="#aries_staticagent.static_connection.StaticConnection.pack">pack</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.reply" href="#aries_staticagent.static_connection.StaticConnection.reply">reply</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.reply_handler" href="#aries_staticagent.static_connection.StaticConnection.reply_handler">reply_handler</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.random" href="#aries_staticagent.static_connection.StaticConnection.random">random</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.receiver" href="#aries_staticagent.static_connection.StaticConnection.receiver">receiver</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.route" href="#aries_staticagent.static_connection.StaticConnection.route">route</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.route_module" href="#aries_staticagent.static_connection.StaticConnection.route_module">route_module</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.send" href="#aries_staticagent.static_connection.StaticConnection.send">send</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.send_and_await_reply" href="#aries_staticagent.static_connection.StaticConnection.send_and_await_reply">send_and_await_reply</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.send_and_await_reply_async" href="#aries_staticagent.static_connection.StaticConnection.send_and_await_reply_async">send_and_await_reply_async</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.send_async" href="#aries_staticagent.static_connection.StaticConnection.send_async">send_async</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.sigkey" href="#aries_staticagent.static_connection.StaticConnection.sigkey">sigkey</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.send_to_session" href="#aries_staticagent.static_connection.StaticConnection.send_to_session">send_to_session</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.session" href="#aries_staticagent.static_connection.StaticConnection.session">session</a></code></li>
+<li><code><a title="aries_staticagent.static_connection.StaticConnection.session_open" href="#aries_staticagent.static_connection.StaticConnection.session_open">session_open</a></code></li>
 <li><code><a title="aries_staticagent.static_connection.StaticConnection.unpack" href="#aries_staticagent.static_connection.StaticConnection.unpack">unpack</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.update" href="#aries_staticagent.static_connection.StaticConnection.update">update</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.verkey" href="#aries_staticagent.static_connection.StaticConnection.verkey">verkey</a></code></li>
-<li><code><a title="aries_staticagent.static_connection.StaticConnection.verkey_b58" href="#aries_staticagent.static_connection.StaticConnection.verkey_b58">verkey_b58</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="aries_staticagent.static_connection.Target" href="#aries_staticagent.static_connection.Target">Target</a></code></h4>
+<ul class="">
+<li><code><a title="aries_staticagent.static_connection.Target.update" href="#aries_staticagent.static_connection.Target.update">update</a></code></li>
 </ul>
 </li>
 </ul>
@@ -1601,9 +2384,7 @@ def reply_handler(
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/type.html
+++ b/docs/aries_staticagent/type.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.type API documentation</title>
 <meta name="description" content="Message and Module Type related classes and helpers." />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -165,10 +167,10 @@ class Type:
 <dl>
 <dt id="aries_staticagent.type.InvalidType"><code class="flex name class">
 <span>class <span class="ident">InvalidType</span></span>
-<span>(</span><span>*args, **kwargs)</span>
+<span>(</span><span>...)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>When type is unparsable or invalid.</p></section>
+<div class="desc"><p>When type is unparsable or invalid.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -184,12 +186,12 @@ class Type:
 </dd>
 <dt id="aries_staticagent.type.Semver"><code class="flex name class">
 <span>class <span class="ident">Semver</span></span>
-<span>(</span><span>major, minor, patch, prerelease=None, build=None)</span>
+<span>(</span><span>major, minor=0, patch=0, prerelease=None, build=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Wrapper around the more complete VersionInfo class from semver package.</p>
+<div class="desc"><p>Wrapper around the more complete VersionInfo class from semver package.</p>
 <p>This wrapper enables abbreviated versions in message types
-(i.e. 1.0 not 1.0.0).</p></section>
+(i.e. 1.0 not 1.0.0).</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -232,7 +234,7 @@ class Type:
 <dl>
 <dt id="aries_staticagent.type.Semver.SEMVER_RE"><code class="name">var <span class="ident">SEMVER_RE</span></code></dt>
 <dd>
-<section class="desc"><p>Compiled regular expression object.</p></section>
+<div class="desc"></div>
 </dd>
 </dl>
 <h3>Static methods</h3>
@@ -241,7 +243,7 @@ class Type:
 <span>def <span class="ident">from_str</span></span>(<span>version_str)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Parse version information from a string.</p></section>
+<div class="desc"><p>Parse version information from a string.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -271,10 +273,10 @@ def from_str(cls, version_str):
 </dd>
 <dt id="aries_staticagent.type.Type"><code class="flex name class">
 <span>class <span class="ident">Type</span></span>
-<span>(</span><span>doc_uri, protocol, version, name)</span>
+<span>(</span><span>doc_uri: str, protocol: str, version: Union[str, <a title="aries_staticagent.type.Semver" href="#aries_staticagent.type.Semver">Semver</a>], name: str)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Message and Module type container</p></section>
+<div class="desc"><p>Message and Module type container</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -366,15 +368,7 @@ def from_str(cls, version_str):
 <dl>
 <dt id="aries_staticagent.type.Type.FORMAT"><code class="name">var <span class="ident">FORMAT</span></code></dt>
 <dd>
-<section class="desc"><p>str(object='') -&gt; str
-str(bytes_or_buffer[, encoding[, errors]]) -&gt; str</p>
-<p>Create a new string object from the given object. If encoding or
-errors is specified, then the object must expose a data buffer
-that will be decoded using the given encoding and error handler.
-Otherwise, returns the result of object.<strong>str</strong>() (if defined)
-or repr(object).
-encoding defaults to sys.getdefaultencoding().
-errors defaults to 'strict'.</p></section>
+<div class="desc"></div>
 </dd>
 </dl>
 <h3>Static methods</h3>
@@ -383,7 +377,7 @@ errors defaults to 'strict'.</p></section>
 <span>def <span class="ident">from_str</span></span>(<span>type_str)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Parse type from string.</p></section>
+<div class="desc"><p>Parse type from string.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -403,15 +397,15 @@ def from_str(cls, type_str):
 <dl>
 <dt id="aries_staticagent.type.Type.doc_uri"><code class="name">var <span class="ident">doc_uri</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.type.Type.name"><code class="name">var <span class="ident">name</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.type.Type.normalized"><code class="name">var <span class="ident">normalized</span></code></dt>
 <dd>
-<section class="desc"><p>Return the normalized string representation</p></section>
+<div class="desc"><p>Return the normalized string representation</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -424,15 +418,15 @@ def normalized(self):
 </dd>
 <dt id="aries_staticagent.type.Type.protocol"><code class="name">var <span class="ident">protocol</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.type.Type.version"><code class="name">var <span class="ident">version</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 <dt id="aries_staticagent.type.Type.version_info"><code class="name">var <span class="ident">version_info</span></code></dt>
 <dd>
-<section class="desc"><p>Return an attribute of instance, which is of type owner.</p></section>
+<div class="desc"><p>Return an attribute of instance, which is of type owner.</p></div>
 </dd>
 </dl>
 </dd>
@@ -481,9 +475,7 @@ def normalized(self):
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/aries_staticagent/utils.html
+++ b/docs/aries_staticagent/utils.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.2" />
+<meta name="generator" content="pdoc 0.8.4" />
 <title>aries_staticagent.utils API documentation</title>
 <meta name="description" content="General utils" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -26,13 +28,23 @@
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">&#34;&#34;&#34; General utils &#34;&#34;&#34;
+from functools import wraps
+from typing import Union, Optional, Callable
+import copy
 import datetime
-from typing import Union, Optional
 
 import aiohttp
 
 from . import crypto
 from .message import Message
+from .mtc import (
+    Context as MTCContext,
+    NONE as NoMTCContext,
+    AUTHCRYPT_AFFIRMED,
+    AUTHCRYPT_DENIED,
+    ANONCRYPT_AFFIRMED,
+    ANONCRYPT_DENIED
+)
 
 
 def timestamp():
@@ -62,7 +74,7 @@ def ensure_key_b58(key: Union[bytes, str]):
     raise TypeError(&#39;key must be bytes or str&#39;)
 
 
-FORWARD = &#39;did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/routing/1.0/forward&#39;
+FORWARD = &#39;https://didcomm.org/routing/1.0/forward&#39;
 
 
 def forward_msg(to: Union[bytes, str], msg: dict):
@@ -72,6 +84,128 @@ def forward_msg(to: Union[bytes, str], msg: dict):
         &#39;to&#39;: ensure_key_b58(to),
         &#39;msg&#39;: msg
     })
+
+
+def find_message_in_args(args):
+    &#34;&#34;&#34;Helper for picking out message from handler arguments.&#34;&#34;&#34;
+    for index, arg in enumerate(args):
+        if isinstance(arg, Message):
+            return arg, index
+    return None
+
+
+def preprocess(preprocessor: Callable):
+    &#34;&#34;&#34;Preprocess a message before handling.
+
+    This facility might be used to validate and unpack signatures/attachments,
+    validate timing or ordering, add data to the message object (i.e. append
+    protocol state information), etc.
+
+    A deep copy of the original message is given to preprocessors to prevent
+    accidental manipulation. Preprocessors must return the altered message
+    object if modification is intended. Preprocessors should raise an error if
+    preprocessing fails.
+    &#34;&#34;&#34;
+    def _preprocess_decorated(func):
+        @wraps(func)
+        def _wrapped(*args, **kwargs):
+            msg, index = find_message_in_args(args)
+            preprocessed = preprocessor(copy.deepcopy(msg))
+
+            if preprocessed:
+                args = list(args)
+                args[index] = preprocessed
+
+            return func(*args, **kwargs)
+        return _wrapped
+    return _preprocess_decorated
+
+
+def preprocess_async(preprocessor: Callable):
+    &#34;&#34;&#34;Asynchronously preprocess a message before handling.
+
+    This follows has the same semantics as `preprocess`, just with an async
+    preprocessor.
+    &#34;&#34;&#34;
+    def _preprocess_decorated(func):
+        @wraps(func)
+        async def _wrapped(*args, **kwargs):
+            msg, index = find_message_in_args(args)
+            preprocessed = await preprocessor(copy.deepcopy(msg))
+
+            if preprocessed:
+                args = list(args)
+                args[index] = preprocessed
+
+            return await func(*args, **kwargs)
+        return _wrapped
+    return _preprocess_decorated
+
+
+class InsufficientMessageTrust(Exception):
+    &#34;&#34;&#34;When a message does not meet the MTC requirements.&#34;&#34;&#34;
+
+
+def mtc(
+        affirmed: MTCContext = NoMTCContext,
+        denied: MTCContext = NoMTCContext
+):
+    &#34;&#34;&#34;
+    Validate that the message passed to this handler has the expected trust
+    context.
+    &#34;&#34;&#34;
+    def _mtc_preprocessor(msg):
+        if msg.mtc.affirmed != affirmed:
+            raise InsufficientMessageTrust(
+                f&#39;Actual affirmed {msg.mtc.affirmed} does not match &#39;
+                f&#39;expected affirmed of {affirmed}&#39;
+            )
+        if msg.mtc.denied != denied:
+            raise InsufficientMessageTrust(
+                f&#39;Actual denied {msg.mtc.denied} does not match expected &#39;
+                f&#39;denied of {denied}&#39;
+            )
+    return preprocess(_mtc_preprocessor)
+
+
+def authcrypted(func):
+    &#34;&#34;&#34;Validate that the message passed to this handler is authcrypted.&#34;&#34;&#34;
+    return mtc(AUTHCRYPT_AFFIRMED, AUTHCRYPT_DENIED)(func)
+
+
+def anoncrypted(func):
+    &#34;&#34;&#34;Validate that the message passed to this handler is anoncrypted.&#34;&#34;&#34;
+    return mtc(ANONCRYPT_AFFIRMED, ANONCRYPT_DENIED)(func)
+
+
+class MessageValidationError(Exception):
+    &#34;&#34;&#34;When message validation fails.&#34;&#34;&#34;
+
+
+def validate(validator: Callable, *, coerce: Optional[Callable] = None):
+    &#34;&#34;&#34;Validate the message passed to this handler using validator.
+
+    A deep copy of the original message is given to validators to prevent
+    accidental manipulation. Validators must return the altered message
+    object if modification is intended. Validators should raise an error if
+    validation fails.
+
+    Args:
+        coerce (Callable): Optionally coerce the value before validation.
+    &#34;&#34;&#34;
+    def _validate_preprocessor(msg):
+        to_be_validated = msg
+        if coerce:
+            to_be_validated = coerce(to_be_validated)
+
+        try:
+            return validator(to_be_validated)
+        except Exception as err:
+            raise MessageValidationError(
+                &#39;Message failed to validate&#39;
+            ) from err
+
+    return preprocess(_validate_preprocessor)
 
 
 async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
@@ -93,7 +227,29 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
             if resp.status == 200 and body:
                 return body
 
-    return None</code></pre>
+    return None
+
+
+# TODO: Persist websocket until return_route = None sent
+async def ws_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
+    &#34;&#34;&#34;Send over WS.
+
+    This send method is experimental and should not be used for more than
+    experimenting. This method is very inefficient as it throws out the created
+    websocket after receiving only a single msg.
+    &#34;&#34;&#34;
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(endpoint) as sock:
+            await sock.send_bytes(msg)
+            async for msg in sock:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    return msg.data
+
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    raise Exception(
+                        &#39;ws connection closed with exception %s&#39; %
+                        sock.exception()
+                    )</code></pre>
 </details>
 </section>
 <section>
@@ -103,11 +259,39 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
-<dt id="aries_staticagent.utils.ensure_key_b58"><code class="name flex">
-<span>def <span class="ident">ensure_key_b58</span></span>(<span>key)</span>
+<dt id="aries_staticagent.utils.anoncrypted"><code class="name flex">
+<span>def <span class="ident">anoncrypted</span></span>(<span>func)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Ensure key is formatted as b58 string.</p></section>
+<div class="desc"><p>Validate that the message passed to this handler is anoncrypted.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def anoncrypted(func):
+    &#34;&#34;&#34;Validate that the message passed to this handler is anoncrypted.&#34;&#34;&#34;
+    return mtc(ANONCRYPT_AFFIRMED, ANONCRYPT_DENIED)(func)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.utils.authcrypted"><code class="name flex">
+<span>def <span class="ident">authcrypted</span></span>(<span>func)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Validate that the message passed to this handler is authcrypted.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def authcrypted(func):
+    &#34;&#34;&#34;Validate that the message passed to this handler is authcrypted.&#34;&#34;&#34;
+    return mtc(AUTHCRYPT_AFFIRMED, AUTHCRYPT_DENIED)(func)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.utils.ensure_key_b58"><code class="name flex">
+<span>def <span class="ident">ensure_key_b58</span></span>(<span>key: Union[bytes, str])</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Ensure key is formatted as b58 string.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -123,10 +307,10 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
 </details>
 </dd>
 <dt id="aries_staticagent.utils.ensure_key_bytes"><code class="name flex">
-<span>def <span class="ident">ensure_key_bytes</span></span>(<span>key)</span>
+<span>def <span class="ident">ensure_key_bytes</span></span>(<span>key: Union[bytes, str])</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Ensure key is formatted as bytes.</p></section>
+<div class="desc"><p>Ensure key is formatted as bytes.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -141,11 +325,28 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
     raise TypeError(&#39;key must be bytes or str&#39;)</code></pre>
 </details>
 </dd>
-<dt id="aries_staticagent.utils.forward_msg"><code class="name flex">
-<span>def <span class="ident">forward_msg</span></span>(<span>to, msg)</span>
+<dt id="aries_staticagent.utils.find_message_in_args"><code class="name flex">
+<span>def <span class="ident">find_message_in_args</span></span>(<span>args)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Return a forward message.</p></section>
+<div class="desc"><p>Helper for picking out message from handler arguments.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def find_message_in_args(args):
+    &#34;&#34;&#34;Helper for picking out message from handler arguments.&#34;&#34;&#34;
+    for index, arg in enumerate(args):
+        if isinstance(arg, Message):
+            return arg, index
+    return None</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.utils.forward_msg"><code class="name flex">
+<span>def <span class="ident">forward_msg</span></span>(<span>to: Union[bytes, str], msg: dict)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return a forward message.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -160,10 +361,10 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
 </details>
 </dd>
 <dt id="aries_staticagent.utils.http_send"><code class="name flex">
-<span>async def <span class="ident">http_send</span></span>(<span>msg, endpoint)</span>
+<span>async def <span class="ident">http_send</span></span>(<span>msg: bytes, endpoint: str) ‑> Union[bytes, NoneType]</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Send over HTTP.</p></section>
+<div class="desc"><p>Send over HTTP.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -190,11 +391,118 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
     return None</code></pre>
 </details>
 </dd>
+<dt id="aries_staticagent.utils.mtc"><code class="name flex">
+<span>def <span class="ident">mtc</span></span>(<span>affirmed: <a title="aries_staticagent.mtc.Context" href="mtc.html#aries_staticagent.mtc.Context">Context</a> = Context.NONE, denied: <a title="aries_staticagent.mtc.Context" href="mtc.html#aries_staticagent.mtc.Context">Context</a> = Context.NONE)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Validate that the message passed to this handler has the expected trust
+context.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def mtc(
+        affirmed: MTCContext = NoMTCContext,
+        denied: MTCContext = NoMTCContext
+):
+    &#34;&#34;&#34;
+    Validate that the message passed to this handler has the expected trust
+    context.
+    &#34;&#34;&#34;
+    def _mtc_preprocessor(msg):
+        if msg.mtc.affirmed != affirmed:
+            raise InsufficientMessageTrust(
+                f&#39;Actual affirmed {msg.mtc.affirmed} does not match &#39;
+                f&#39;expected affirmed of {affirmed}&#39;
+            )
+        if msg.mtc.denied != denied:
+            raise InsufficientMessageTrust(
+                f&#39;Actual denied {msg.mtc.denied} does not match expected &#39;
+                f&#39;denied of {denied}&#39;
+            )
+    return preprocess(_mtc_preprocessor)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.utils.preprocess"><code class="name flex">
+<span>def <span class="ident">preprocess</span></span>(<span>preprocessor: Callable)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Preprocess a message before handling.</p>
+<p>This facility might be used to validate and unpack signatures/attachments,
+validate timing or ordering, add data to the message object (i.e. append
+protocol state information), etc.</p>
+<p>A deep copy of the original message is given to preprocessors to prevent
+accidental manipulation. Preprocessors must return the altered message
+object if modification is intended. Preprocessors should raise an error if
+preprocessing fails.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def preprocess(preprocessor: Callable):
+    &#34;&#34;&#34;Preprocess a message before handling.
+
+    This facility might be used to validate and unpack signatures/attachments,
+    validate timing or ordering, add data to the message object (i.e. append
+    protocol state information), etc.
+
+    A deep copy of the original message is given to preprocessors to prevent
+    accidental manipulation. Preprocessors must return the altered message
+    object if modification is intended. Preprocessors should raise an error if
+    preprocessing fails.
+    &#34;&#34;&#34;
+    def _preprocess_decorated(func):
+        @wraps(func)
+        def _wrapped(*args, **kwargs):
+            msg, index = find_message_in_args(args)
+            preprocessed = preprocessor(copy.deepcopy(msg))
+
+            if preprocessed:
+                args = list(args)
+                args[index] = preprocessed
+
+            return func(*args, **kwargs)
+        return _wrapped
+    return _preprocess_decorated</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.utils.preprocess_async"><code class="name flex">
+<span>def <span class="ident">preprocess_async</span></span>(<span>preprocessor: Callable)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Asynchronously preprocess a message before handling.</p>
+<p>This follows has the same semantics as <code><a title="aries_staticagent.utils.preprocess" href="#aries_staticagent.utils.preprocess">preprocess()</a></code>, just with an async
+preprocessor.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def preprocess_async(preprocessor: Callable):
+    &#34;&#34;&#34;Asynchronously preprocess a message before handling.
+
+    This follows has the same semantics as `preprocess`, just with an async
+    preprocessor.
+    &#34;&#34;&#34;
+    def _preprocess_decorated(func):
+        @wraps(func)
+        async def _wrapped(*args, **kwargs):
+            msg, index = find_message_in_args(args)
+            preprocessed = await preprocessor(copy.deepcopy(msg))
+
+            if preprocessed:
+                args = list(args)
+                args[index] = preprocessed
+
+            return await func(*args, **kwargs)
+        return _wrapped
+    return _preprocess_decorated</code></pre>
+</details>
+</dd>
 <dt id="aries_staticagent.utils.timestamp"><code class="name flex">
 <span>def <span class="ident">timestamp</span></span>(<span>)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>return a timestamp.</p></section>
+<div class="desc"><p>return a timestamp.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -206,9 +514,127 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
     ).isoformat(&#39; &#39;)</code></pre>
 </details>
 </dd>
+<dt id="aries_staticagent.utils.validate"><code class="name flex">
+<span>def <span class="ident">validate</span></span>(<span>validator: Callable, *, coerce: Union[Callable, NoneType] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Validate the message passed to this handler using validator.</p>
+<p>A deep copy of the original message is given to validators to prevent
+accidental manipulation. Validators must return the altered message
+object if modification is intended. Validators should raise an error if
+validation fails.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>coerce</code></strong> :&ensp;<code>Callable</code></dt>
+<dd>Optionally coerce the value before validation.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def validate(validator: Callable, *, coerce: Optional[Callable] = None):
+    &#34;&#34;&#34;Validate the message passed to this handler using validator.
+
+    A deep copy of the original message is given to validators to prevent
+    accidental manipulation. Validators must return the altered message
+    object if modification is intended. Validators should raise an error if
+    validation fails.
+
+    Args:
+        coerce (Callable): Optionally coerce the value before validation.
+    &#34;&#34;&#34;
+    def _validate_preprocessor(msg):
+        to_be_validated = msg
+        if coerce:
+            to_be_validated = coerce(to_be_validated)
+
+        try:
+            return validator(to_be_validated)
+        except Exception as err:
+            raise MessageValidationError(
+                &#39;Message failed to validate&#39;
+            ) from err
+
+    return preprocess(_validate_preprocessor)</code></pre>
+</details>
+</dd>
+<dt id="aries_staticagent.utils.ws_send"><code class="name flex">
+<span>async def <span class="ident">ws_send</span></span>(<span>msg: bytes, endpoint: str) ‑> Union[bytes, NoneType]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Send over WS.</p>
+<p>This send method is experimental and should not be used for more than
+experimenting. This method is very inefficient as it throws out the created
+websocket after receiving only a single msg.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def ws_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
+    &#34;&#34;&#34;Send over WS.
+
+    This send method is experimental and should not be used for more than
+    experimenting. This method is very inefficient as it throws out the created
+    websocket after receiving only a single msg.
+    &#34;&#34;&#34;
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(endpoint) as sock:
+            await sock.send_bytes(msg)
+            async for msg in sock:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    return msg.data
+
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    raise Exception(
+                        &#39;ws connection closed with exception %s&#39; %
+                        sock.exception()
+                    )</code></pre>
+</details>
+</dd>
 </dl>
 </section>
 <section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="aries_staticagent.utils.InsufficientMessageTrust"><code class="flex name class">
+<span>class <span class="ident">InsufficientMessageTrust</span></span>
+<span>(</span><span>...)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>When a message does not meet the MTC requirements.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InsufficientMessageTrust(Exception):
+    &#34;&#34;&#34;When a message does not meet the MTC requirements.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+<dt id="aries_staticagent.utils.MessageValidationError"><code class="flex name class">
+<span>class <span class="ident">MessageValidationError</span></span>
+<span>(</span><span>...)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>When message validation fails.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MessageValidationError(Exception):
+    &#34;&#34;&#34;When message validation fails.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+</dd>
+</dl>
 </section>
 </article>
 <nav id="sidebar">
@@ -224,20 +650,36 @@ async def http_send(msg: bytes, endpoint: str) -&gt; Optional[bytes]:
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
+<li><code><a title="aries_staticagent.utils.anoncrypted" href="#aries_staticagent.utils.anoncrypted">anoncrypted</a></code></li>
+<li><code><a title="aries_staticagent.utils.authcrypted" href="#aries_staticagent.utils.authcrypted">authcrypted</a></code></li>
 <li><code><a title="aries_staticagent.utils.ensure_key_b58" href="#aries_staticagent.utils.ensure_key_b58">ensure_key_b58</a></code></li>
 <li><code><a title="aries_staticagent.utils.ensure_key_bytes" href="#aries_staticagent.utils.ensure_key_bytes">ensure_key_bytes</a></code></li>
+<li><code><a title="aries_staticagent.utils.find_message_in_args" href="#aries_staticagent.utils.find_message_in_args">find_message_in_args</a></code></li>
 <li><code><a title="aries_staticagent.utils.forward_msg" href="#aries_staticagent.utils.forward_msg">forward_msg</a></code></li>
 <li><code><a title="aries_staticagent.utils.http_send" href="#aries_staticagent.utils.http_send">http_send</a></code></li>
+<li><code><a title="aries_staticagent.utils.mtc" href="#aries_staticagent.utils.mtc">mtc</a></code></li>
+<li><code><a title="aries_staticagent.utils.preprocess" href="#aries_staticagent.utils.preprocess">preprocess</a></code></li>
+<li><code><a title="aries_staticagent.utils.preprocess_async" href="#aries_staticagent.utils.preprocess_async">preprocess_async</a></code></li>
 <li><code><a title="aries_staticagent.utils.timestamp" href="#aries_staticagent.utils.timestamp">timestamp</a></code></li>
+<li><code><a title="aries_staticagent.utils.validate" href="#aries_staticagent.utils.validate">validate</a></code></li>
+<li><code><a title="aries_staticagent.utils.ws_send" href="#aries_staticagent.utils.ws_send">ws_send</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="aries_staticagent.utils.InsufficientMessageTrust" href="#aries_staticagent.utils.InsufficientMessageTrust">InsufficientMessageTrust</a></code></h4>
+</li>
+<li>
+<h4><code><a title="aries_staticagent.utils.MessageValidationError" href="#aries_staticagent.utils.MessageValidationError">MessageValidationError</a></code></h4>
+</li>
 </ul>
 </li>
 </ul>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.2</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.4</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,7 +120,7 @@ With the static agent connection `a`, to send messages to the full agent:
 
 ```python
 conn.send({
-    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message",
+    "@type": "https://didcomm.org/basicmessage/1.0/message",
     "~l10n": {"locale": "en"},
     "sent_time": utils.timestamp(),
     "content": "The Cron Script has been executed."
@@ -130,7 +130,7 @@ conn.send({
 An asynchronous method is also provided:
 ```python
 await conn.send_async({
-    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message",
+    "@type": "https://didcomm.org/basicmessage/1.0/message",
     "~l10n": {"locale": "en"},
     "sent_time": utils.timestamp(),
     "content": "The Cron Script has been executed."
@@ -154,11 +154,11 @@ from aries_staticagent import StaticConnection, utils
 conn = StaticConnection.from_parts((args.mypublickey, args.myprivatekey), their_vk=args.endpointkey, endpoint=args.endpoint)
 
 # Register a handler for the basicmessage/1.0/message message type
-@conn.route("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message")
+@conn.route("https://didcomm.org/basicmessage/1.0/message")
 async def basic_message(msg, conn):
     # Respond to the received basic message by sending another basic message back
     await conn.send_async({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message",
+        "@type": "https://didcomm.org/basicmessage/1.0/message",
         "~l10n": {"locale": "en"},
         "sent_time": utils.timestamp(),
         "content": "You said: {}".format(msg['content'])

--- a/examples/preprocessors.py
+++ b/examples/preprocessors.py
@@ -5,7 +5,7 @@ from aries_staticagent import StaticConnection, utils
 
 from common import config
 
-TYPE = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message"
+TYPE = "https://didcomm.org/basicmessage/1.0/message"
 
 
 def validate_basic_message(msg):
@@ -32,7 +32,7 @@ def main():
     async def basic_message(msg, conn):
         """Respond to a basic message."""
         await conn.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),

--- a/examples/return_route_client.py
+++ b/examples/return_route_client.py
@@ -22,7 +22,7 @@ def main():
         )
     )
     reply = conn.send_and_await_reply({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+        "@type": "https://didcomm.org/"
                  "basicmessage/1.0/message",
         "~l10n": {"locale": "en"},
         "sent_time": utils.timestamp(),

--- a/examples/return_route_server.py
+++ b/examples/return_route_server.py
@@ -20,10 +20,10 @@ def main():
         Target(their_vk=their_vk)
     )
 
-    @conn.route('did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message')
+    @conn.route('https://didcomm.org/basicmessage/1.0/message')
     async def basic_message_auto_responder(msg, conn):
         await conn.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),

--- a/examples/webserver_aiohttp.py
+++ b/examples/webserver_aiohttp.py
@@ -10,11 +10,11 @@ def main():
     keys, target, args = config()
     conn = StaticConnection(keys, target)
 
-    @conn.route("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message")
+    @conn.route("https://didcomm.org/basicmessage/1.0/message")
     async def basic_message(msg, conn):
         """Respond to a basic message."""
         await conn.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),

--- a/examples/webserver_with_module.py
+++ b/examples/webserver_with_module.py
@@ -11,7 +11,7 @@ class BasicMessageCounter(Module):
 
     Responds with the number of messages received.
     """
-    DOC_URI = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'
+    DOC_URI = 'https://didcomm.org/'
     PROTOCOL = 'basicmessage'
     VERSION = '1.0'
 

--- a/examples/webserver_with_websockets.py
+++ b/examples/webserver_with_websockets.py
@@ -13,11 +13,11 @@ def main():
     keys, target, args = config()
     conn = StaticConnection(keys, target)
 
-    @conn.route("did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message")
+    @conn.route("https://didcomm.org/basicmessage/1.0/message")
     async def basic_message(msg, conn):
         """Respond to a basic message."""
         await conn.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -122,7 +122,7 @@ async def test_webserver_aiohttp(
 
     with connection.next() as next_msg:
         await connection.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),
@@ -161,7 +161,7 @@ async def test_preprocessor_example(
 
     with connection.next() as next_msg:
         await connection.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),
@@ -201,7 +201,7 @@ async def test_webserver_with_websockets(
 
     with connection_ws.next() as next_msg:
         await connection_ws.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),
@@ -239,7 +239,7 @@ async def test_webserver_with_module(
 
     with connection.next() as next_msg:
         await connection.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),
@@ -252,7 +252,7 @@ async def test_webserver_with_module(
 
     with connection.next() as next_msg:
         await connection.send_async({
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+            "@type": "https://didcomm.org/"
                      "basicmessage/1.0/message",
             "~l10n": {"locale": "en"},
             "sent_time": utils.timestamp(),

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -45,9 +45,9 @@ def test_bad_version_raises_error(version_arg):
             ]
         ),
         (
-            'did:sov:12345678987654321;spec/test_protocol/2.0/test_type',
+            'https://didcomm.org/test_protocol/2.0/test_type',
             [
-                'did:sov:12345678987654321;spec/',
+                'https://didcomm.org/',
                 'test_protocol',
                 '2.0',
                 'test_type'


### PR DESCRIPTION
This PR updates types to the new didcomm.org URL. It should be noted that these types were only used in examples and testing with only one exception: the forward message (used for packaging outbound messages).

> As an aside, it seems to be a common misconception that this library handles messages. However, this library provides only a framework for handling messages. The only message type "built-in" to the library is the `forward` message but this is only used for correctly packaging an outbound message. No default handler is present for forwarding messages meaning if the agent receives a message with type `forward`, it will not know what to do with it without having a registered handler for messages with type `forward`.