### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,13 +7,12 @@
 | Name             | Github           | LFID             |
 | ---------------- | ---------------- | ---------------- |
 | Daniel Bluhm     | dbluhm           | dbluhm           |
-| Sam Curren       | TelegramSam      | TelegramSam      |
 
 ## Emeritus Maintainers
 
 | Name         | Github  | LFID    |
 |--------------|---------|---------|
-|   |  |  |
+| Sam Curren       | TelegramSam      | TelegramSam      |
 
 ## Becoming a Maintainer
 


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>